### PR TITLE
Add external output support

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -38,6 +38,7 @@ config("flutter_tizen_config") {
     "${sysroot_path}/usr/include/elementary-1",
     "${sysroot_path}/usr/include/emile-1",
     "${sysroot_path}/usr/include/eo-1",
+    "${sysroot_path}/usr/include/eom",
     "${sysroot_path}/usr/include/ethumb-1",
     "${sysroot_path}/usr/include/ethumb-client-1",
     "${sysroot_path}/usr/include/evas-1",
@@ -160,7 +161,9 @@ template("embedder") {
       libs += [
         "tzsh_common",
         "tzsh_softkey",
+        "eom",
       ]
+      defines += [ "EOM_SUPPORT" ]
     }
 
     defines += invoker.defines

--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -128,6 +128,7 @@ template("embedder") {
       "efl-extension",
       "eina",
       "elementary",
+      "eom",
       "evas",
       "feedback",
       "flutter_engine",
@@ -159,7 +160,6 @@ template("embedder") {
       sources += [ "channels/tizen_shell.cc" ]
 
       libs += [
-        "eom",
         "tzsh_common",
         "tzsh_softkey",
       ]

--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -159,11 +159,10 @@ template("embedder") {
       sources += [ "channels/tizen_shell.cc" ]
 
       libs += [
+        "eom",
         "tzsh_common",
         "tzsh_softkey",
-        "eom",
       ]
-      defines += [ "EOM_SUPPORT" ]
     }
 
     defines += invoker.defines

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -204,7 +204,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
   if (window_properties.renderer_type == FlutterDesktopRendererType::kEvasGL) {
     window = std::make_unique<flutter::TizenWindowElementary>(
         window_geometry, window_properties.transparent,
-        window_properties.focusable, window_properties.top_level);
+        window_properties.focusable, window_properties.top_level,
+        window_properties.external_output_type);
   } else {
 #ifndef WEARABLE_PROFILE
     window = std::make_unique<flutter::TizenWindowEcoreWl2>(

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -38,6 +38,13 @@ typedef enum {
   kMouseMove,
 } FlutterDesktopPointerEventType;
 
+typedef enum {
+  // No use external output.
+  kNone,
+  // Display to the HDMI external output.
+  kHDMI,
+} FlutterDesktopExternalOutputType;
+
 // Properties for configuring the initial settings of a Flutter window.
 typedef struct {
   // The x-coordinate of the top left corner of the window.
@@ -56,6 +63,8 @@ typedef struct {
   bool top_level;
   // The renderer type of the engine.
   FlutterDesktopRendererType renderer_type;
+  // The external output type of the window.
+  FlutterDesktopExternalOutputType external_output_type;
 } FlutterDesktopWindowProperties;
 
 // Properties for configuring the initial settings of a Flutter view.

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -39,7 +39,7 @@ typedef enum {
 } FlutterDesktopPointerEventType;
 
 typedef enum {
-  // No use external output.
+  // No external output.
   kNone,
   // Display to the HDMI external output.
   kHDMI,

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -5,7 +5,7 @@
 #include "tizen_window_elementary.h"
 
 #include <efl_extension.h>
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
 #include <eom.h>
 #endif
 #include <ui/efl_util.h>
@@ -44,7 +44,7 @@ TizenWindowElementary::TizenWindowElementary(
     bool top_level,
     FlutterDesktopExternalOutputType external_output_type)
     : TizenWindow(geometry, transparent, focusable, top_level) {
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
   external_output_type_ = external_output_type;
 
   if (external_output_type_ != FlutterDesktopExternalOutputType::kNone &&
@@ -70,7 +70,7 @@ TizenWindowElementary::TizenWindowElementary(
 }
 
 TizenWindowElementary::~TizenWindowElementary() {
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
   if (external_output_type_ != FlutterDesktopExternalOutputType::kNone) {
     DestroyEom();
   }
@@ -94,7 +94,7 @@ bool TizenWindowElementary::CreateWindow() {
 #endif
 
   int32_t width, height;
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
   if (external_output_type_ != FlutterDesktopExternalOutputType::kNone) {
     eom_get_output_resolution(ext_output_id_, &width, &height);
 
@@ -444,7 +444,7 @@ void TizenWindowElementary::PrepareInputMethod() {
       [this](std::string str) { view_delegate_->OnCommit(str); });
 }
 
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
 
 int32_t TizenWindowElementary::GetExternalOutputId() {
   eom_output_id* output_ids = NULL;

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -436,7 +436,9 @@ int32_t TizenWindowElementary::GetExternalOutputId() {
     return 0;
   }
 
+  eom_output_id output_id = 0;
   for (int32_t i = 0; i < id_cnt; i++) {
+    eom_output_type_e output_type = EOM_OUTPUT_TYPE_UNKNOWN;
     eom_get_output_type(output_ids[i], &output_type);
 
     if (external_output_type_ == FlutterDesktopExternalOutputType::kHDMI &&

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -429,12 +429,8 @@ void TizenWindowElementary::PrepareInputMethod() {
 }
 
 int32_t TizenWindowElementary::GetExternalOutputId() {
-  eom_output_id* output_ids = nullptr;
-  eom_output_id output_id = 0;
-  eom_output_type_e output_type = EOM_OUTPUT_TYPE_UNKNOWN;
-  int32_t id_cnt = 0;
-
-  output_ids = eom_get_eom_output_ids(&id_cnt);
+  int32_t num_ids = 0;
+  eom_output_id* output_ids = eom_get_eom_output_ids(&num_ids);
   if (!output_ids || id_cnt == 0) {
     FT_LOG(Error) << "No external output found.";
     return 0;

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -431,13 +431,13 @@ void TizenWindowElementary::PrepareInputMethod() {
 int32_t TizenWindowElementary::GetExternalOutputId() {
   int32_t num_ids = 0;
   eom_output_id* output_ids = eom_get_eom_output_ids(&num_ids);
-  if (!output_ids || id_cnt == 0) {
+  if (!output_ids || num_ids == 0) {
     FT_LOG(Error) << "No external output found.";
     return 0;
   }
 
   eom_output_id output_id = 0;
-  for (int32_t i = 0; i < id_cnt; i++) {
+  for (int32_t i = 0; i < num_ids; i++) {
     eom_output_type_e output_type = EOM_OUTPUT_TYPE_UNKNOWN;
     eom_get_output_type(output_ids[i], &output_type);
 
@@ -461,7 +461,6 @@ bool TizenWindowElementary::InitializeExternalOutputManager() {
   external_output_id_ = GetExternalOutputId();
   if (external_output_id_ == 0) {
     FT_LOG(Error) << "Invalid external output ID.";
-    eom_deinit();
     return false;
   }
 
@@ -470,7 +469,6 @@ bool TizenWindowElementary::InitializeExternalOutputManager() {
   if (ret != EOM_ERROR_NONE) {
     FT_LOG(Error)
         << "eom_set_output_attribute() failed. Cannot use external output.";
-    eom_deinit();
     return false;
   }
   return true;

--- a/flutter/shell/platform/tizen/tizen_window_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.h
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "flutter/shell/platform/tizen/public/flutter_tizen.h"
 #include "flutter/shell/platform/tizen/tizen_window.h"
 
 namespace flutter {
@@ -21,7 +22,8 @@ class TizenWindowElementary : public TizenWindow {
   TizenWindowElementary(TizenGeometry geometry,
                         bool transparent,
                         bool focusable,
-                        bool top_level);
+                        bool top_level,
+                        FlutterDesktopExternalOutputType external_output_type);
 
   ~TizenWindowElementary();
 
@@ -50,6 +52,14 @@ class TizenWindowElementary : public TizenWindow {
   void Show() override;
 
  private:
+#ifdef EOM_SUPPORT
+  bool InitializeEom();
+
+  void DestroyEom();
+
+  int GetExternalOutputId();
+#endif
+
   bool CreateWindow();
 
   void DestroyWindow();
@@ -68,6 +78,12 @@ class TizenWindowElementary : public TizenWindow {
   Evas_Smart_Cb rotation_changed_callback_ = nullptr;
   std::unordered_map<Evas_Callback_Type, Evas_Object_Event_Cb>
       evas_object_callbacks_;
+
+#ifdef EOM_SUPPORT
+  int ext_output_id_;
+  FlutterDesktopExternalOutputType external_output_type_ =
+      FlutterDesktopExternalOutputType::kNone;
+#endif
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_window_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.h
@@ -52,7 +52,7 @@ class TizenWindowElementary : public TizenWindow {
   void Show() override;
 
  private:
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
   bool InitializeEom();
 
   void DestroyEom();
@@ -79,7 +79,7 @@ class TizenWindowElementary : public TizenWindow {
   std::unordered_map<Evas_Callback_Type, Evas_Object_Event_Cb>
       evas_object_callbacks_;
 
-#ifdef EOM_SUPPORT
+#ifdef COMMON_PROFILE
   int ext_output_id_;
   FlutterDesktopExternalOutputType external_output_type_ =
       FlutterDesktopExternalOutputType::kNone;

--- a/flutter/shell/platform/tizen/tizen_window_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.h
@@ -52,13 +52,11 @@ class TizenWindowElementary : public TizenWindow {
   void Show() override;
 
  private:
-#ifdef COMMON_PROFILE
-  bool InitializeEom();
+  bool InitializeExternalOutputManager();
 
-  void DestroyEom();
+  void DestroyExternalOutputManager();
 
   int GetExternalOutputId();
-#endif
 
   bool CreateWindow();
 
@@ -79,11 +77,9 @@ class TizenWindowElementary : public TizenWindow {
   std::unordered_map<Evas_Callback_Type, Evas_Object_Event_Cb>
       evas_object_callbacks_;
 
-#ifdef COMMON_PROFILE
-  int ext_output_id_;
+  int32_t external_output_id_;
   FlutterDesktopExternalOutputType external_output_type_ =
       FlutterDesktopExternalOutputType::kNone;
-#endif
 };
 
 }  // namespace flutter

--- a/tools/generate_sysroot.py
+++ b/tools/generate_sysroot.py
@@ -85,6 +85,8 @@ unified_packages = [
   'jsoncpp-devel',
   'libatk',
   'libatk-bridge-2_0-0',
+  'libeom',
+  'libeom-devel',
   'libfeedback',
   'libfeedback-devel',
   'libdlog',
@@ -109,8 +111,6 @@ unified_packages = [
   'vulkan-loader-devel',
   'wayland-extension-client-devel',
   'wayland-devel',
-  'libeom',
-  'libeom-devel',
 ]
 
 # Only available for Tizen 6.5 and above.

--- a/tools/generate_sysroot.py
+++ b/tools/generate_sysroot.py
@@ -109,6 +109,8 @@ unified_packages = [
   'vulkan-loader-devel',
   'wayland-extension-client-devel',
   'wayland-devel',
+  'libeom',
+  'libeom-devel',
 ]
 
 # Only available for Tizen 6.5 and above.


### PR DESCRIPTION
Add feature to support external output in common profile.
The eom API only supports elm_win. So TizenWindowElementary supports this.
Currently, only HDMI type is available.
It can be extended according to the requirements of the Common profile.

https://docs.tizen.org/application/native/guides/device/ext-output/

+)
How to map input device.
1) Check to input event node.
$) winfo -input_devices
2) Set to input and output event node 
$) winfo -input_output_set [input(ex./dev/input/eventX)] [output(ex.HDMIA-1)]

related pr : https://github.com/flutter-tizen/flutter-tizen/pull/465