### PR TITLE
[ci] Fix check-symbols failing on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/tools/check_symbols.py
+++ b/tools/check_symbols.py
@@ -21,6 +21,7 @@ class Symbol:
 
   @staticmethod
   def parse(line):
+    # Format: "         U abort@GLIBC_2.4" (addr can be empty)
     return Symbol(line[:8].strip(), line[9], line[11:].strip().split('@')[0])
 
 

--- a/tools/check_symbols.py
+++ b/tools/check_symbols.py
@@ -21,7 +21,7 @@ class Symbol:
 
   @staticmethod
   def parse(line):
-    return Symbol(line[:8].strip(), line[9], line[11:].strip())
+    return Symbol(line[:8].strip(), line[9], line[11:].strip().split('@')[0])
 
 
 def check_symbol(sofile, allowlist):


### PR DESCRIPTION
The ubuntu-latest image now maps to ubuntu-22.04 on GitHub Actions. Ignore the symbol version part of the `nm` output.

https://github.com/flutter-tizen/embedder/actions/runs/3528676880