### PR TITLE
TizenRendererEgl: Use AnyCast() to cast to tbm_surface_queue

### DIFF
--- a/flutter/shell/platform/tizen/tizen_renderer_egl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_egl.cc
@@ -85,9 +85,8 @@ bool TizenRendererEgl::CreateSurface(void* render_target,
       Dali::NativeImageSourceQueuePtr dali_native_image_queue =
           static_cast<Dali::NativeImageSourceQueue*>(render_target);
       tbm_surface_queue_h tbm_surface_queue_ =
-          static_cast<Dali::Any::AnyContainerImpl<tbm_surface_queue_h>*>(
-              dali_native_image_queue->GetNativeImageSourceQueue().mContainer)
-              ->GetValue();
+          Dali::AnyCast<tbm_surface_queue_h>(
+              dali_native_image_queue->GetNativeImageSourceQueue());
       auto* egl_window =
           reinterpret_cast<EGLNativeWindowType*>(tbm_surface_queue_);
       egl_surface_ = eglCreateWindowSurface(egl_display_, egl_config_,


### PR DESCRIPTION
Previously, there was a problem using Dali::AnyCast() due to libcxx issues.
The embedder has been migrated not to use flutter's libcxx(use_flutter_cxx option)
Therefore, there is no need to directly access the implementation of container of Dali::Any.
So it changed to cast to tbm_surface_queue_h using Dali::AnyCast().