### PR TITLE
Improve the clipboard implementation

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -13,6 +13,7 @@ config("flutter_tizen_config") {
   include_dirs = [
     "${sysroot_path}/usr/include/appfw",
     "${sysroot_path}/usr/include/base",
+    "${sysroot_path}/usr/include/cbhm",
     "${sysroot_path}/usr/include/dali",
     "${sysroot_path}/usr/include/dali-adaptor",
     "${sysroot_path}/usr/include/dali-toolkit",
@@ -163,6 +164,11 @@ template("embedder") {
         "tzsh_common",
         "tzsh_softkey",
       ]
+    }
+
+    if (target_name == "flutter_tizen_mobile" ||
+        target_name == "flutter_tizen_common") {
+      libs += [ "cbhm" ]
     }
 
     defines += invoker.defines

--- a/flutter/shell/platform/tizen/channels/app_control.cc
+++ b/flutter/shell/platform/tizen/channels/app_control.cc
@@ -323,6 +323,8 @@ AppControlResult AppControl::SendLaunchRequest() {
 
 AppControlResult AppControl::SendLaunchRequestWithReply(
     ReplyCallback on_reply) {
+  on_reply_ = std::move(on_reply);
+
   auto reply_callback = [](app_control_h request, app_control_h reply,
                            app_control_result_e result, void* user_data) {
     auto* app_control = static_cast<AppControl*>(user_data);
@@ -342,7 +344,6 @@ AppControlResult AppControl::SendLaunchRequestWithReply(
     app_control->on_reply_(EncodableValue(map));
     app_control->on_reply_ = nullptr;
   };
-  on_reply_ = on_reply;
   return app_control_send_launch_request(handle_, reply_callback, this);
 }
 

--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -188,7 +188,7 @@ void PlatformChannel::HapticFeedbackVibrate(const std::string& feedback_type) {
 }
 
 void PlatformChannel::GetClipboardData(ClipboardCallback on_data) {
-  on_clipboard_data_ = on_data;
+  on_clipboard_data_ = std::move(on_data);
 
 #if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
   int ret = cbhm_selection_get(

--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -57,10 +57,6 @@ constexpr char kPortraitDown[] = "DeviceOrientation.portraitDown";
 constexpr char kLandscapeLeft[] = "DeviceOrientation.landscapeLeft";
 constexpr char kLandscapeRight[] = "DeviceOrientation.landscapeRight";
 
-// Naive implementation using std::string as a container of internal clipboard
-// data.
-std::string text_clipboard = "";
-
 }  // namespace
 
 PlatformChannel::PlatformChannel(BinaryMessenger* messenger,
@@ -70,6 +66,13 @@ PlatformChannel::PlatformChannel(BinaryMessenger* messenger,
           kChannelName,
           &JsonMethodCodec::GetInstance())),
       view_(view) {
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+  int ret = cbhm_open_service(&cbhm_handle_);
+  if (ret != CBHM_ERROR_NONE) {
+    FT_LOG(Error) << "Failed to initialize the clipboard service.";
+  }
+#endif
+
   channel_->SetMethodCallHandler(
       [this](const MethodCall<rapidjson::Document>& call,
              std::unique_ptr<MethodResult<rapidjson::Document>> result) {
@@ -77,7 +80,11 @@ PlatformChannel::PlatformChannel(BinaryMessenger* messenger,
       });
 }
 
-PlatformChannel::~PlatformChannel() {}
+PlatformChannel::~PlatformChannel() {
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+  cbhm_close_service(cbhm_handle_);
+#endif
+}
 
 void PlatformChannel::HandleMethodCall(
     const MethodCall<rapidjson::Document>& method_call,
@@ -100,18 +107,21 @@ void PlatformChannel::HandleMethodCall(
     result->Success();
   } else if (method == kGetClipboardDataMethod) {
     // https://api.flutter.dev/flutter/services/Clipboard/kTextPlain-constant.html
-    // The API supports only kTextPlain format.
+    // The API only supports the plain text format.
     if (strcmp(arguments[0].GetString(), kTextPlainFormat) != 0) {
       result->Error(kUnknownClipboardFormatError,
                     "Clipboard API only supports text.");
       return;
     }
-    rapidjson::Document document;
-    document.SetObject();
-    rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
-    document.AddMember(rapidjson::Value(kTextKey, allocator),
-                       rapidjson::Value(text_clipboard, allocator), allocator);
-    result->Success(document);
+    GetClipboardData([result = result.release()](const std::string& data) {
+      rapidjson::Document document;
+      document.SetObject();
+      rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
+      document.AddMember(rapidjson::Value(kTextKey, allocator),
+                         rapidjson::Value(data, allocator), allocator);
+      result->Success(document);
+      delete result;
+    });
   } else if (method == kSetClipboardDataMethod) {
     const rapidjson::Value& document = *arguments;
     auto iter = document.FindMember(kTextKey);
@@ -119,14 +129,14 @@ void PlatformChannel::HandleMethodCall(
       result->Error(kUnknownClipboardError, "Invalid message format.");
       return;
     }
-    text_clipboard = iter->value.GetString();
+    SetClipboardData(iter->value.GetString());
     result->Success();
   } else if (method == kClipboardHasStringsMethod) {
     rapidjson::Document document;
     document.SetObject();
     rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
     document.AddMember(rapidjson::Value(kValueKey, allocator),
-                       rapidjson::Value(!text_clipboard.empty()), allocator);
+                       rapidjson::Value(ClipboardHasStrings()), allocator);
     result->Success(document);
   } else if (method == kRestoreSystemUiOverlaysMethod) {
     RestoreSystemUiOverlays();
@@ -175,6 +185,59 @@ void PlatformChannel::PlaySystemSound(const std::string& sound_type) {
 
 void PlatformChannel::HapticFeedbackVibrate(const std::string& feedback_type) {
   FeedbackManager::GetInstance().Vibrate();
+}
+
+void PlatformChannel::GetClipboardData(ClipboardCallback on_data) {
+  on_clipboard_data_ = on_data;
+
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+  int ret = cbhm_selection_get(
+      cbhm_handle_, CBHM_SEL_TYPE_TEXT,
+      [](cbhm_h cbhm_handle, const char* buf, size_t len,
+         void* user_data) -> int {
+        auto* self = static_cast<PlatformChannel*>(user_data);
+        std::string data;
+        if (buf) {
+          data = std::string(buf, len);
+        }
+        self->on_clipboard_data_(data);
+        self->on_clipboard_data_ = nullptr;
+        return CBHM_ERROR_NONE;
+      },
+      this);
+  if (ret != CBHM_ERROR_NONE) {
+    if (ret == CBHM_ERROR_NO_DATA) {
+      FT_LOG(Info) << "No clipboard data available.";
+    } else {
+      FT_LOG(Error) << "Failed to get clipboard data.";
+    }
+    on_clipboard_data_("");
+    on_clipboard_data_ = nullptr;
+  }
+#else
+  on_clipboard_data_(clipboard_);
+  on_clipboard_data_ = nullptr;
+#endif
+}
+
+void PlatformChannel::SetClipboardData(const std::string& data) {
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+  int ret = cbhm_selection_set(cbhm_handle_, CBHM_SEL_TYPE_TEXT, data.c_str(),
+                               data.length());
+  if (ret != CBHM_ERROR_NONE) {
+    FT_LOG(Error) << "Failed to set clipboard data.";
+  }
+#else
+  clipboard_ = data;
+#endif
+}
+
+bool PlatformChannel::ClipboardHasStrings() {
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+  return cbhm_item_count_get(cbhm_handle_) > 0;
+#else
+  return !clipboard_.empty();
+#endif
 }
 
 void PlatformChannel::RestoreSystemUiOverlays() {

--- a/flutter/shell/platform/tizen/channels/platform_channel.h
+++ b/flutter/shell/platform/tizen/channels/platform_channel.h
@@ -5,7 +5,9 @@
 #ifndef EMBEDDER_PLATFORM_CHANNEL_H_
 #define EMBEDDER_PLATFORM_CHANNEL_H_
 
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
 #include <cbhm.h>
+#endif
 
 #include <functional>
 #include <memory>
@@ -46,14 +48,16 @@ class PlatformChannel {
   // A reference to the native view managed by FlutterTizenView.
   TizenViewBase* view_ = nullptr;
 
+#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
   // The clipboard history manager.
-  [[maybe_unused]] cbhm_h cbhm_handle_ = nullptr;
-
+  cbhm_h cbhm_handle_ = nullptr;
+#else
   // A container that holds clipboard data during the engine lifetime.
   //
   // Only used by profiles that do not support the Tizen clipboard API
   // (wearable and TV).
   std::string clipboard_;
+#endif
 
   ClipboardCallback on_clipboard_data_ = nullptr;
 };

--- a/flutter/shell/platform/tizen/channels/platform_channel.h
+++ b/flutter/shell/platform/tizen/channels/platform_channel.h
@@ -5,6 +5,9 @@
 #ifndef EMBEDDER_PLATFORM_CHANNEL_H_
 #define EMBEDDER_PLATFORM_CHANNEL_H_
 
+#include <cbhm.h>
+
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,6 +25,8 @@ class PlatformChannel {
   virtual ~PlatformChannel();
 
  private:
+  using ClipboardCallback = std::function<void(const std::string& data)>;
+
   void HandleMethodCall(
       const MethodCall<rapidjson::Document>& call,
       std::unique_ptr<MethodResult<rapidjson::Document>> result);
@@ -29,6 +34,9 @@ class PlatformChannel {
   void SystemNavigatorPop();
   void PlaySystemSound(const std::string& sound_type);
   void HapticFeedbackVibrate(const std::string& feedback_type);
+  void GetClipboardData(ClipboardCallback on_data);
+  void SetClipboardData(const std::string& data);
+  bool ClipboardHasStrings();
   void RestoreSystemUiOverlays();
   void SetEnabledSystemUiOverlays(const std::vector<std::string>& overlays);
   void SetPreferredOrientations(const std::vector<std::string>& orientations);
@@ -36,7 +44,18 @@ class PlatformChannel {
   std::unique_ptr<MethodChannel<rapidjson::Document>> channel_;
 
   // A reference to the native view managed by FlutterTizenView.
-  TizenViewBase* view_;
+  TizenViewBase* view_ = nullptr;
+
+  // The clipboard history manager.
+  [[maybe_unused]] cbhm_h cbhm_handle_ = nullptr;
+
+  // A container that holds clipboard data during the engine lifetime.
+  //
+  // Only used by profiles that do not support the Tizen clipboard API
+  // (wearable and TV).
+  std::string clipboard_;
+
+  ClipboardCallback on_clipboard_data_ = nullptr;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/channels/window_channel.h
+++ b/flutter/shell/platform/tizen/channels/window_channel.h
@@ -27,7 +27,7 @@ class WindowChannel {
   std::unique_ptr<MethodChannel<EncodableValue>> channel_;
 
   // A reference to the native window managed by FlutterTizenView.
-  TizenWindow* window_;
+  TizenWindow* window_ = nullptr;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Use the platform clipboard API (CBHM) to implement a text clipboard that supports app-to-app copy-and-paste (including non-Flutter apps). The API is only available for mobile and common profiles, so other profiles will continue to use the old naive implementation that comes with limited functionality.

See also: https://github.com/flutter-tizen/engine/pull/65 (the original implementation by @pkosko)