### PR TITLE
TizenViewBase: Remove TizenViewType enum and GetType()

### DIFF
--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -168,8 +168,7 @@ void PlatformChannel::HandleMethodCall(
 }
 
 void PlatformChannel::SystemNavigatorPop() {
-  auto* view = dynamic_cast<TizenView*>(view_);
-  if (view) {
+  if (auto* view = dynamic_cast<TizenView*>(view_)) {
     view->SetFocus(false);
   } else {
     ui_app_exit();
@@ -242,66 +241,57 @@ bool PlatformChannel::ClipboardHasStrings() {
 }
 
 void PlatformChannel::RestoreSystemUiOverlays() {
-  auto* window = dynamic_cast<TizenWindow*>(view_);
-  if (!window) {
-    return;
-  }
-
+  if (auto* window = dynamic_cast<TizenWindow*>(view_)) {
 #ifdef COMMON_PROFILE
-  auto& shell = TizenShell::GetInstance();
-  shell.InitializeSoftkey(window->GetWindowId());
+    auto& shell = TizenShell::GetInstance();
+    shell.InitializeSoftkey(window->GetWindowId());
 
-  if (shell.IsSoftkeyShown()) {
-    shell.ShowSoftkey();
-  } else {
-    shell.HideSoftkey();
-  }
+    if (shell.IsSoftkeyShown()) {
+      shell.ShowSoftkey();
+    } else {
+      shell.HideSoftkey();
+    }
 #endif
+  }
 }
 
 void PlatformChannel::SetEnabledSystemUiOverlays(
     const std::vector<std::string>& overlays) {
-  auto* window = dynamic_cast<TizenWindow*>(view_);
-  if (!window) {
-    return;
-  }
-
+  if (auto* window = dynamic_cast<TizenWindow*>(view_)) {
 #ifdef COMMON_PROFILE
-  auto& shell = TizenShell::GetInstance();
-  shell.InitializeSoftkey(window->GetWindowId());
+    auto& shell = TizenShell::GetInstance();
+    shell.InitializeSoftkey(window->GetWindowId());
 
-  if (std::find(overlays.begin(), overlays.end(), kSystemUiOverlayBottom) !=
-      overlays.end()) {
-    shell.ShowSoftkey();
-  } else {
-    shell.HideSoftkey();
-  }
+    if (std::find(overlays.begin(), overlays.end(), kSystemUiOverlayBottom) !=
+        overlays.end()) {
+      shell.ShowSoftkey();
+    } else {
+      shell.HideSoftkey();
+    }
 #endif
+  }
 }
 
 void PlatformChannel::SetPreferredOrientations(
     const std::vector<std::string>& orientations) {
-  auto* window = dynamic_cast<TizenWindow*>(view_);
-  if (!window) {
-    return;
+  if (auto* window = dynamic_cast<TizenWindow*>(view_)) {
+    static const std::map<std::string, int> orientation_mapping = {
+        {kPortraitUp, 0},
+        {kLandscapeLeft, 90},
+        {kPortraitDown, 180},
+        {kLandscapeRight, 270},
+    };
+    std::vector<int> rotations;
+    for (const auto& orientation : orientations) {
+      rotations.push_back(orientation_mapping.at(orientation));
+    }
+    if (rotations.empty()) {
+      // The empty list causes the application to defer to the operating system
+      // default.
+      rotations = {0, 90, 180, 270};
+    }
+    window->SetPreferredOrientations(rotations);
   }
-
-  static const std::map<std::string, int> orientation_mapping = {
-      {kPortraitUp, 0},
-      {kLandscapeLeft, 90},
-      {kPortraitDown, 180},
-      {kLandscapeRight, 270},
-  };
-  std::vector<int> rotations;
-  for (const auto& orientation : orientations) {
-    rotations.push_back(orientation_mapping.at(orientation));
-  }
-  if (rotations.empty()) {
-    // The empty list causes the application to defer to the operating system
-    // default.
-    rotations = {0, 90, 180, 270};
-  }
-  window->SetPreferredOrientations(rotations);
 }
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -168,10 +168,11 @@ void PlatformChannel::HandleMethodCall(
 }
 
 void PlatformChannel::SystemNavigatorPop() {
-  if (view_->GetType() == TizenViewType::kWindow) {
-    ui_app_exit();
+  auto* view = dynamic_cast<TizenView*>(view_);
+  if (view) {
+    view->SetFocus(false);
   } else {
-    reinterpret_cast<TizenView*>(view_)->SetFocus(false);
+    ui_app_exit();
   }
 }
 
@@ -241,13 +242,14 @@ bool PlatformChannel::ClipboardHasStrings() {
 }
 
 void PlatformChannel::RestoreSystemUiOverlays() {
-  if (view_->GetType() != TizenViewType::kWindow) {
+  auto* window = dynamic_cast<TizenWindow*>(view_);
+  if (!window) {
     return;
   }
 
 #ifdef COMMON_PROFILE
   auto& shell = TizenShell::GetInstance();
-  shell.InitializeSoftkey(view_->GetWindowId());
+  shell.InitializeSoftkey(window->GetWindowId());
 
   if (shell.IsSoftkeyShown()) {
     shell.ShowSoftkey();
@@ -259,13 +261,14 @@ void PlatformChannel::RestoreSystemUiOverlays() {
 
 void PlatformChannel::SetEnabledSystemUiOverlays(
     const std::vector<std::string>& overlays) {
-  if (view_->GetType() != TizenViewType::kWindow) {
+  auto* window = dynamic_cast<TizenWindow*>(view_);
+  if (!window) {
     return;
   }
 
 #ifdef COMMON_PROFILE
   auto& shell = TizenShell::GetInstance();
-  shell.InitializeSoftkey(view_->GetWindowId());
+  shell.InitializeSoftkey(window->GetWindowId());
 
   if (std::find(overlays.begin(), overlays.end(), kSystemUiOverlayBottom) !=
       overlays.end()) {
@@ -278,7 +281,8 @@ void PlatformChannel::SetEnabledSystemUiOverlays(
 
 void PlatformChannel::SetPreferredOrientations(
     const std::vector<std::string>& orientations) {
-  if (view_->GetType() != TizenViewType::kWindow) {
+  auto* window = dynamic_cast<TizenWindow*>(view_);
+  if (!window) {
     return;
   }
 
@@ -297,7 +301,7 @@ void PlatformChannel::SetPreferredOrientations(
     // default.
     rotations = {0, 90, 180, 270};
   }
-  reinterpret_cast<TizenWindow*>(view_)->SetPreferredOrientations(rotations);
+  window->SetPreferredOrientations(rotations);
 }
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -280,13 +280,16 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
                                   size_t timestamp,
                                   bool is_down) {
 #ifdef NUI_SUPPORT
-  auto* tizen_view =
-      dynamic_cast<flutter::TizenViewNui*>(ViewFromHandle(view)->tizen_view());
-  if (tizen_view && ViewFromHandle(view)->engine()->renderer()->type() ==
-                        FlutterDesktopRendererType::kEGL) {
-    tizen_view->OnKey(device_name, device_class, device_subclass, key, string,
-                      nullptr, modifiers, scan_code, timestamp, is_down);
+
+  if (auto* tizen_view = dynamic_cast<flutter::TizenViewNui*>(
+          ViewFromHandle(view)->tizen_view())) {
+    if (ViewFromHandle(view)->engine()->renderer()->type() ==
+        FlutterDesktopRendererType::kEGL) {
+      tizen_view->OnKey(device_name, device_class, device_subclass, key, string,
+                        nullptr, modifiers, scan_code, timestamp, is_down);
+    }
   }
+
 #else
   ViewFromHandle(view)->OnKey(key, string, nullptr, modifiers, scan_code,
                               is_down);
@@ -294,17 +297,15 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
 }
 
 void FlutterDesktopViewSetFocus(FlutterDesktopViewRef view, bool focused) {
-  auto* tizen_view =
-      dynamic_cast<flutter::TizenView*>(ViewFromHandle(view)->tizen_view());
-  if (tizen_view) {
+  if (auto* tizen_view = dynamic_cast<flutter::TizenView*>(
+          ViewFromHandle(view)->tizen_view())) {
     tizen_view->SetFocus(focused);
   }
 }
 
 bool FlutterDesktopViewIsFocused(FlutterDesktopViewRef view) {
-  auto* tizen_view =
-      dynamic_cast<flutter::TizenView*>(ViewFromHandle(view)->tizen_view());
-  if (tizen_view) {
+  if (auto* tizen_view = dynamic_cast<flutter::TizenView*>(
+          ViewFromHandle(view)->tizen_view())) {
     return tizen_view->focused();
   }
   return false;

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -280,15 +280,12 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
                                   size_t timestamp,
                                   bool is_down) {
 #ifdef NUI_SUPPORT
-  auto* tizen_view = reinterpret_cast<flutter::TizenViewBase*>(
-      ViewFromHandle(view)->tizen_view());
-
-  if (tizen_view->GetType() == flutter::TizenViewType::kView &&
-      ViewFromHandle(view)->engine()->renderer()->type() ==
-          FlutterDesktopRendererType::kEGL) {
-    reinterpret_cast<flutter::TizenViewNui*>(tizen_view)
-        ->OnKey(device_name, device_class, device_subclass, key, string,
-                nullptr, modifiers, scan_code, timestamp, is_down);
+  auto* tizen_view =
+      dynamic_cast<flutter::TizenViewNui*>(ViewFromHandle(view)->tizen_view());
+  if (tizen_view && ViewFromHandle(view)->engine()->renderer()->type() ==
+                        FlutterDesktopRendererType::kEGL) {
+    tizen_view->OnKey(device_name, device_class, device_subclass, key, string,
+                      nullptr, modifiers, scan_code, timestamp, is_down);
   }
 #else
   ViewFromHandle(view)->OnKey(key, string, nullptr, modifiers, scan_code,
@@ -297,18 +294,18 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
 }
 
 void FlutterDesktopViewSetFocus(FlutterDesktopViewRef view, bool focused) {
-  auto* tizen_view = reinterpret_cast<flutter::TizenViewBase*>(
-      ViewFromHandle(view)->tizen_view());
-  if (tizen_view->GetType() == flutter::TizenViewType::kView) {
-    reinterpret_cast<flutter::TizenView*>(tizen_view)->SetFocus(focused);
+  auto* tizen_view =
+      dynamic_cast<flutter::TizenView*>(ViewFromHandle(view)->tizen_view());
+  if (tizen_view) {
+    tizen_view->SetFocus(focused);
   }
 }
 
 bool FlutterDesktopViewIsFocused(FlutterDesktopViewRef view) {
-  auto* tizen_view = reinterpret_cast<flutter::TizenViewBase*>(
-      ViewFromHandle(view)->tizen_view());
-  if (tizen_view->GetType() == flutter::TizenViewType::kView) {
-    return reinterpret_cast<flutter::TizenView*>(tizen_view)->focused();
+  auto* tizen_view =
+      dynamic_cast<flutter::TizenView*>(ViewFromHandle(view)->tizen_view());
+  if (tizen_view) {
+    return tizen_view->focused();
   }
   return false;
 }

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -280,7 +280,6 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
                                   size_t timestamp,
                                   bool is_down) {
 #ifdef NUI_SUPPORT
-
   if (auto* tizen_view = dynamic_cast<flutter::TizenViewNui*>(
           ViewFromHandle(view)->tizen_view())) {
     if (ViewFromHandle(view)->engine()->renderer()->type() ==
@@ -289,7 +288,6 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
                         nullptr, modifiers, scan_code, timestamp, is_down);
     }
   }
-
 #else
   ViewFromHandle(view)->OnKey(key, string, nullptr, modifiers, scan_code,
                               is_down);

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -50,8 +50,7 @@ FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
     : tizen_view_(std::move(tizen_view)) {
   tizen_view_->SetView(this);
 
-  auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get());
-  if (window) {
+  if (auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get())) {
     window->BindKeys(kBindableSystemKeys);
   }
 }
@@ -132,9 +131,10 @@ bool FlutterTizenView::OnMakeResourceCurrent() {
 bool FlutterTizenView::OnPresent() {
   bool result = engine_->renderer()->OnPresent();
 #ifdef NUI_SUPPORT
-  auto* view = dynamic_cast<TizenViewNui*>(tizen_view_.get());
-  if (view && engine_->renderer()->type() == FlutterDesktopRendererType::kEGL) {
-    view->RequestRendering();
+  if (auto* view = dynamic_cast<TizenViewNui*>(tizen_view_.get())) {
+    if (engine_->renderer()->type() == FlutterDesktopRendererType::kEGL) {
+      view->RequestRendering();
+    }
   }
 #endif
   return result;
@@ -305,8 +305,7 @@ void FlutterTizenView::OnCommit(const std::string& str) {
 }
 
 void FlutterTizenView::SendInitialGeometry() {
-  auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get());
-  if (window) {
+  if (auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get())) {
     OnRotate(window->GetRotation());
   } else {
     TizenGeometry geometry = tizen_view_->GetGeometry();

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -5,6 +5,8 @@
 
 #include "flutter_tizen_view.h"
 
+#include <iostream>
+
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view.h"
 #ifdef NUI_SUPPORT
@@ -49,6 +51,7 @@ namespace flutter {
 FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
     : tizen_view_(std::move(tizen_view)) {
   tizen_view_->SetView(this);
+
   auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get());
   if (window) {
     window->BindKeys(kBindableSystemKeys);
@@ -90,7 +93,7 @@ void FlutterTizenView::CreateRenderSurface(
 
   if (engine_ && engine_->renderer()) {
     TizenGeometry geometry = tizen_view_->GetGeometry();
-    if (dynamic_cast<TizenWindow*>(tizen_view_.get())) {
+    if (typeid(TizenWindow) == typeid(tizen_view_)) {
       auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get());
       engine_->renderer()->CreateSurface(window->GetRenderTarget(),
                                          window->GetRenderTargetDisplay(),

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -5,8 +5,6 @@
 
 #include "flutter_tizen_view.h"
 
-#include <iostream>
-
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view.h"
 #ifdef NUI_SUPPORT
@@ -93,7 +91,7 @@ void FlutterTizenView::CreateRenderSurface(
 
   if (engine_ && engine_->renderer()) {
     TizenGeometry geometry = tizen_view_->GetGeometry();
-    if (typeid(TizenWindow) == typeid(tizen_view_)) {
+    if (dynamic_cast<TizenWindow*>(tizen_view_.get())) {
       auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get());
       engine_->renderer()->CreateSurface(window->GetRenderTarget(),
                                          window->GetRenderTargetDisplay(),

--- a/flutter/shell/platform/tizen/tizen_view.h
+++ b/flutter/shell/platform/tizen/tizen_view.h
@@ -18,8 +18,6 @@ class TizenView : public TizenViewBase {
   TizenView() = default;
   virtual ~TizenView() = default;
 
-  TizenViewType GetType() override { return TizenViewType::kView; };
-
   bool focused() { return focused_; };
 
   void SetFocus(bool focused) { focused_ = focused; };

--- a/flutter/shell/platform/tizen/tizen_view_base.h
+++ b/flutter/shell/platform/tizen/tizen_view_base.h
@@ -19,8 +19,6 @@ struct TizenGeometry {
   int32_t left = 0, top = 0, width = 0, height = 0;
 };
 
-enum class TizenViewType { kView, kWindow };
-
 class TizenViewBase {
  public:
   TizenViewBase() = default;
@@ -50,8 +48,6 @@ class TizenViewBase {
   }
 
   virtual void Show() = 0;
-
-  virtual TizenViewType GetType() = 0;
 
   TizenInputMethodContext* input_method_context() {
     return input_method_context_.get();

--- a/flutter/shell/platform/tizen/tizen_window.h
+++ b/flutter/shell/platform/tizen/tizen_window.h
@@ -30,8 +30,6 @@ class TizenWindow : public TizenViewBase {
 
   virtual void BindKeys(const std::vector<std::string>& keys) = 0;
 
-  TizenViewType GetType() override { return TizenViewType::kWindow; };
-
  protected:
   explicit TizenWindow(TizenGeometry geometry,
                        bool transparent,


### PR DESCRIPTION
The embedder does not require a type for the class because -rtti option is enabled.
So, remove the type enum and the getter method.