### PR TITLE
TizenRenderer: Remove renderer type getter

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -174,7 +174,7 @@ template("embedder") {
     defines += invoker.defines
     defines += [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
 
-    if (api_version == "6.5") {
+    if (api_version == "6.5" && target_name != "flutter_tizen_wearable") {
       sources += [
         "flutter_tizen_nui.cc",
         "tizen_view_nui.cc",

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -15,6 +15,7 @@
 #include "flutter/shell/platform/tizen/public/flutter_platform_view.h"
 #include "flutter/shell/platform/tizen/tizen_view.h"
 #ifdef NUI_SUPPORT
+#include "flutter/shell/platform/tizen/tizen_renderer_egl.h"
 #include "flutter/shell/platform/tizen/tizen_view_nui.h"
 #endif
 #include "flutter/shell/platform/tizen/tizen_window.h"
@@ -280,13 +281,10 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
                                   size_t timestamp,
                                   bool is_down) {
 #ifdef NUI_SUPPORT
-  if (auto* tizen_view = dynamic_cast<flutter::TizenViewNui*>(
+  if (auto* nui_view = dynamic_cast<flutter::TizenViewNui*>(
           ViewFromHandle(view)->tizen_view())) {
-    if (ViewFromHandle(view)->engine()->renderer()->type() ==
-        FlutterDesktopRendererType::kEGL) {
-      tizen_view->OnKey(device_name, device_class, device_subclass, key, string,
-                        nullptr, modifiers, scan_code, timestamp, is_down);
-    }
+    nui_view->OnKey(device_name, device_class, device_subclass, key, string,
+                    nullptr, modifiers, scan_code, timestamp, is_down);
   }
 #else
   ViewFromHandle(view)->OnKey(key, string, nullptr, modifiers, scan_code,

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -160,7 +160,7 @@ bool FlutterTizenEngine::RunEngine() {
 
   FlutterTaskRunnerDescription render_task_runner = {};
 
-  if (IsHeaded() && renderer_->type() == FlutterDesktopRendererType::kEvasGL) {
+  if (IsHeaded() && dynamic_cast<TizenRendererEvasGL*>(renderer_.get())) {
     render_task_runner.struct_size = sizeof(FlutterTaskRunnerDescription);
     render_task_runner.user_data = render_loop_.get();
     render_task_runner.runs_task_on_current_thread_callback =
@@ -209,7 +209,7 @@ bool FlutterTizenEngine::RunEngine() {
   args.update_semantics_node_callback = OnUpdateSemanticsNode;
   args.update_semantics_custom_action_callback = OnUpdateSemanticsCustomActions;
 
-  if (IsHeaded() && renderer_->type() == FlutterDesktopRendererType::kEGL) {
+  if (IsHeaded() && dynamic_cast<TizenRendererEgl*>(renderer_.get())) {
     vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
     args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
       auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);

--- a/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -15,6 +15,7 @@
 #include "flutter/shell/platform/tizen/external_texture_surface_evas_gl.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
+#include "flutter/shell/platform/tizen/tizen_renderer_evas_gl.h"
 
 namespace flutter {
 
@@ -44,8 +45,8 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
     }
   }
   FlutterDesktopRendererType renderer_type = FlutterDesktopRendererType::kEGL;
-  if (engine_->renderer()) {
-    renderer_type = engine_->renderer()->type();
+  if (dynamic_cast<TizenRendererEvasGL*>(engine_->renderer())) {
+    renderer_type = FlutterDesktopRendererType::kEvasGL;
   }
   std::unique_ptr<ExternalTexture> texture_gl =
       CreateExternalTexture(texture_info, renderer_type);

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -10,6 +10,9 @@
 #ifdef NUI_SUPPORT
 #include "flutter/shell/platform/tizen/tizen_view_nui.h"
 #endif
+#ifndef WEARABLE_PROFILE
+#include "flutter/shell/platform/tizen/tizen_renderer_egl.h"
+#endif
 #include "flutter/shell/platform/tizen/tizen_window.h"
 
 namespace {
@@ -131,10 +134,9 @@ bool FlutterTizenView::OnMakeResourceCurrent() {
 bool FlutterTizenView::OnPresent() {
   bool result = engine_->renderer()->OnPresent();
 #ifdef NUI_SUPPORT
-  if (auto* view = dynamic_cast<TizenViewNui*>(tizen_view_.get())) {
-    if (engine_->renderer()->type() == FlutterDesktopRendererType::kEGL) {
-      view->RequestRendering();
-    }
+  if (auto* nui_view =
+          dynamic_cast<flutter::TizenViewNui*>(tizen_view_.get())) {
+    nui_view->RequestRendering();
   }
 #endif
   return result;
@@ -165,8 +167,8 @@ void FlutterTizenView::OnRotate(int32_t degree) {
   TizenGeometry geometry = tizen_view_->GetGeometry();
   int32_t width = geometry.width;
   int32_t height = geometry.height;
-
-  if (engine_->renderer()->type() == FlutterDesktopRendererType::kEGL) {
+#ifndef WEARABLE_PROFILE
+  if (dynamic_cast<TizenRendererEgl*>(engine_->renderer())) {
     rotation_degree_ = degree;
     // Compute renderer transformation based on the angle of rotation.
     double rad = (360 - rotation_degree_) * M_PI / 180;
@@ -190,6 +192,7 @@ void FlutterTizenView::OnRotate(int32_t degree) {
       std::swap(width, height);
     }
   }
+#endif
 
   engine_->renderer()->ResizeSurface(width, height);
 

--- a/flutter/shell/platform/tizen/tizen_renderer.h
+++ b/flutter/shell/platform/tizen/tizen_renderer.h
@@ -7,8 +7,6 @@
 
 #include <cstdint>
 
-#include "flutter/shell/platform/tizen/public/flutter_tizen.h"
-
 namespace flutter {
 
 class TizenRenderer {

--- a/flutter/shell/platform/tizen/tizen_renderer.h
+++ b/flutter/shell/platform/tizen/tizen_renderer.h
@@ -26,8 +26,6 @@ class TizenRenderer {
 
   bool IsValid() { return is_valid_; }
 
-  FlutterDesktopRendererType type() { return type_; }
-
   virtual bool OnMakeCurrent() = 0;
 
   virtual bool OnClearCurrent() = 0;
@@ -46,8 +44,6 @@ class TizenRenderer {
 
  protected:
   bool is_valid_ = false;
-
-  FlutterDesktopRendererType type_;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_renderer_egl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_egl.cc
@@ -19,9 +19,7 @@
 
 namespace flutter {
 
-TizenRendererEgl::TizenRendererEgl() {
-  type_ = FlutterDesktopRendererType::kEGL;
-}
+TizenRendererEgl::TizenRendererEgl() {}
 
 TizenRendererEgl::~TizenRendererEgl() {
   DestroySurface();

--- a/flutter/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -14,9 +14,7 @@ EVAS_GL_GLOBAL_GLES2_DEFINE();
 
 namespace flutter {
 
-TizenRendererEvasGL::TizenRendererEvasGL() {
-  type_ = FlutterDesktopRendererType::kEvasGL;
-}
+TizenRendererEvasGL::TizenRendererEvasGL() {}
 
 TizenRendererEvasGL::~TizenRendererEvasGL() {
   DestroySurface();


### PR DESCRIPTION
The embedder does not require a type getter of renderer because -rtti option is enabled.
So, remove getter method.