### PR TITLE
[tools] Install CIPD ninja using DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,6 +26,15 @@ deps = {
     ],
     'dep_type': 'cipd',
   },
+  'src/third_party/ninja': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': 'version:2@1.8.2.chromium.3',
+      }
+    ],
+    'dep_type': 'cipd',
+  },
 }
 
 hooks = [


### PR DESCRIPTION
The ninja binary is being removed from depot_tools.

https://bugs.chromium.org/p/chromium/issues/detail?id=1340825

Fixes the following error.

```sh
depot_tools/ninja.py: Could not find Ninja in the third_party of the current project, nor in your PATH.
Please take a following action to install Ninja.
- If your project has DEPS, Add a CIPD Ninja dependency to DEPS.
- Oterweise, Add Ninja to your PATH *after* depot_tools.
Error: Process completed with exit code 1.
```