### PR TITLE
[a11y] Move to new update semantics API

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -202,14 +202,8 @@ class FlutterTizenEngine {
   FlutterRendererConfig GetRendererConfig();
 
 #ifndef WEARABLE_PROFILE
-  // Called when a semantics node update is received from the engine.
-  static void OnUpdateSemanticsNode(const FlutterSemanticsNode* node,
-                                    void* user_data);
-
-  // Called when a semantics actions update is received from the engine.
-  static void OnUpdateSemanticsCustomActions(
-      const FlutterSemanticsCustomAction* action,
-      void* user_data);
+  // Called when semantics nodes updates are received from the engine.
+  void OnUpdateSemantics(const FlutterSemanticsUpdate* update);
 #endif
 
   // The Flutter engine instance.


### PR DESCRIPTION
Align the Tizen embedder with the new `update_semantics_callback` embedder API.

For details, please see https://github.com/flutter/engine/pull/37404. I referred to Windows and macOS implementations.