### PR TITLE
Minimize use of reinterpret_cast

### DIFF
--- a/flutter/shell/platform/tizen/accessibility_settings.cc
+++ b/flutter/shell/platform/tizen/accessibility_settings.cc
@@ -59,7 +59,7 @@ void AccessibilitySettings::OnHighContrastStateChanged(
     system_settings_key_e key,
     void* user_data) {
 #ifdef TV_PROFILE
-  auto* self = reinterpret_cast<AccessibilitySettings*>(user_data);
+  auto* self = static_cast<AccessibilitySettings*>(user_data);
 
   int enabled = 0;
   int ret = system_settings_get_value_int(
@@ -77,7 +77,7 @@ void AccessibilitySettings::OnScreenReaderStateChanged(
     system_settings_key_e key,
     void* user_data) {
 #ifndef WEARABLE_PROFILE
-  auto* self = reinterpret_cast<AccessibilitySettings*>(user_data);
+  auto* self = static_cast<AccessibilitySettings*>(user_data);
 
   bool enabled = false;
   int ret = system_settings_get_value_bool(key, &enabled);

--- a/flutter/shell/platform/tizen/channels/app_control.cc
+++ b/flutter/shell/platform/tizen/channels/app_control.cc
@@ -20,7 +20,7 @@ int32_t NativeCreateAppControl(Dart_Handle handle) {
   Dart_NewFinalizableHandle_DL(
       handle, app_control.get(), 64,
       [](void* isolate_callback_data, void* peer) {
-        auto* app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        auto* app_control = static_cast<flutter::AppControl*>(peer);
         flutter::AppControlManager::GetInstance().Remove(app_control->id());
       });
   flutter::AppControlManager::GetInstance().Insert(std::move(app_control));
@@ -34,7 +34,7 @@ bool NativeAttachAppControl(int32_t id, Dart_Handle handle) {
   }
   Dart_NewFinalizableHandle_DL(
       handle, app_control, 64, [](void* isolate_callback_data, void* peer) {
-        auto* app_control = reinterpret_cast<flutter::AppControl*>(peer);
+        auto* app_control = static_cast<flutter::AppControl*>(peer);
         flutter::AppControlManager::GetInstance().Remove(app_control->id());
       });
   return true;

--- a/flutter/shell/platform/tizen/channels/key_event_channel.cc
+++ b/flutter/shell/platform/tizen/channels/key_event_channel.cc
@@ -250,8 +250,7 @@ void KeyEventChannel::SendEmbedderEvent(const char* key,
   send_event_(
       event,
       [](bool handled, void* user_data) {
-        auto* callback =
-            reinterpret_cast<std::function<void(bool)>*>(user_data);
+        auto* callback = static_cast<std::function<void(bool)>*>(user_data);
         (*callback)(handled);
         delete callback;
       },

--- a/flutter/shell/platform/tizen/channels/settings_channel.cc
+++ b/flutter/shell/platform/tizen/channels/settings_channel.cc
@@ -28,14 +28,14 @@ SettingsChannel::SettingsChannel(BinaryMessenger* messenger)
   system_settings_set_changed_cb(
       SYSTEM_SETTINGS_KEY_LOCALE_TIMEFORMAT_24HOUR,
       [](system_settings_key_e key, void* user_data) -> void {
-        auto* self = reinterpret_cast<SettingsChannel*>(user_data);
+        auto* self = static_cast<SettingsChannel*>(user_data);
         self->SendSettingsEvent();
       },
       this);
   system_settings_set_changed_cb(
       SYSTEM_SETTINGS_KEY_FONT_SIZE,
       [](system_settings_key_e key, void* user_data) -> void {
-        auto* self = reinterpret_cast<SettingsChannel*>(user_data);
+        auto* self = static_cast<SettingsChannel*>(user_data);
         self->SendSettingsEvent();
       },
       this);

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -236,9 +236,7 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
 
 void* FlutterDesktopViewGetNativeHandle(FlutterDesktopViewRef view_ref) {
   flutter::FlutterTizenView* view = ViewFromHandle(view_ref);
-  auto* tizen_view =
-      reinterpret_cast<flutter::TizenViewBase*>(view->tizen_view());
-  return tizen_view->GetNativeHandle();
+  return view->tizen_view()->GetNativeHandle();
 }
 
 void FlutterDesktopViewResize(FlutterDesktopViewRef view,

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -193,7 +193,7 @@ bool FlutterTizenEngine::RunEngine() {
                         << engine_message->struct_size;
           return;
         }
-        auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+        auto* engine = static_cast<FlutterTizenEngine*>(user_data);
         FlutterDesktopMessage message =
             engine->ConvertToDesktopMessage(*engine_message);
         engine->message_dispatcher_->HandleMessage(message);
@@ -215,7 +215,7 @@ bool FlutterTizenEngine::RunEngine() {
   if (IsHeaded() && dynamic_cast<TizenRendererEgl*>(renderer_.get())) {
     vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
     args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       engine->vsync_waiter_->AsyncWaitForVsync(baton);
     };
   }
@@ -430,35 +430,35 @@ FlutterRendererConfig FlutterTizenEngine::GetRendererConfig() {
     config.type = kOpenGL;
     config.open_gl.struct_size = sizeof(config.open_gl);
     config.open_gl.make_current = [](void* user_data) -> bool {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
       return engine->view()->OnMakeCurrent();
     };
     config.open_gl.make_resource_current = [](void* user_data) -> bool {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
       return engine->view()->OnMakeResourceCurrent();
     };
     config.open_gl.clear_current = [](void* user_data) -> bool {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
       return engine->view()->OnClearCurrent();
     };
     config.open_gl.present = [](void* user_data) -> bool {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
       return engine->view()->OnPresent();
     };
     config.open_gl.fbo_callback = [](void* user_data) -> uint32_t {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
@@ -466,7 +466,7 @@ FlutterRendererConfig FlutterTizenEngine::GetRendererConfig() {
     };
     config.open_gl.surface_transformation =
         [](void* user_data) -> FlutterTransformation {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return FlutterTransformation();
       }
@@ -474,7 +474,7 @@ FlutterRendererConfig FlutterTizenEngine::GetRendererConfig() {
     };
     config.open_gl.gl_proc_resolver = [](void* user_data,
                                          const char* name) -> void* {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return nullptr;
       }
@@ -483,7 +483,7 @@ FlutterRendererConfig FlutterTizenEngine::GetRendererConfig() {
     config.open_gl.gl_external_texture_frame_callback =
         [](void* user_data, int64_t texture_id, size_t width, size_t height,
            FlutterOpenGLTexture* texture) -> bool {
-      auto* engine = reinterpret_cast<FlutterTizenEngine*>(user_data);
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->texture_registrar()) {
         return false;
       }

--- a/flutter/shell/platform/tizen/tizen_event_loop.cc
+++ b/flutter/shell/platform/tizen/tizen_event_loop.cc
@@ -19,7 +19,7 @@ TizenEventLoop::TizenEventLoop(std::thread::id main_thread_id,
       on_task_expired_(std::move(on_task_expired)) {
   ecore_pipe_ = ecore_pipe_add(
       [](void* data, void* buffer, unsigned int nbyte) -> void {
-        auto* self = reinterpret_cast<TizenEventLoop*>(data);
+        auto* self = static_cast<TizenEventLoop*>(data);
         self->ExecuteTaskEvents();
       },
       this);
@@ -79,7 +79,7 @@ void TizenEventLoop::PostTask(FlutterTask flutter_task,
     ecore_timer_add(
         flutter_duration / 1000000000.0,
         [](void* data) -> Eina_Bool {
-          auto* self = reinterpret_cast<TizenEventLoop*>(data);
+          auto* self = static_cast<TizenEventLoop*>(data);
           if (self->ecore_pipe_) {
             ecore_pipe_write(self->ecore_pipe_, nullptr, 0);
           }

--- a/flutter/shell/platform/tizen/tizen_input_method_context.cc
+++ b/flutter/shell/platform/tizen/tizen_input_method_context.cc
@@ -163,38 +163,34 @@ bool TizenInputMethodContext::HandleEcoreEventKey(Ecore_Event_Key* event,
                                                   bool is_down) {
   FT_ASSERT(imf_context_);
   FT_ASSERT(event);
+
+  Ecore_IMF_Event imf_event;
   if (is_down) {
-    Ecore_IMF_Event_Key_Down imf_event =
+    imf_event.key_down =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Down>(event);
-    return ecore_imf_context_filter_event(
-        imf_context_, ECORE_IMF_EVENT_KEY_DOWN,
-        reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+    return ecore_imf_context_filter_event(imf_context_,
+                                          ECORE_IMF_EVENT_KEY_DOWN, &imf_event);
   } else {
-    Ecore_IMF_Event_Key_Up imf_event =
+    imf_event.key_up =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Up>(event);
-    return ecore_imf_context_filter_event(
-        imf_context_, ECORE_IMF_EVENT_KEY_UP,
-        reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+    return ecore_imf_context_filter_event(imf_context_, ECORE_IMF_EVENT_KEY_UP,
+                                          &imf_event);
   }
 }
 
 bool TizenInputMethodContext::HandleEvasEventKeyDown(
     Evas_Event_Key_Down* event) {
-  Ecore_IMF_Event_Key_Down imf_event;
-  ecore_imf_evas_event_key_down_wrap(event, &imf_event);
-
-  return ecore_imf_context_filter_event(
-      imf_context_, ECORE_IMF_EVENT_KEY_DOWN,
-      reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+  Ecore_IMF_Event imf_event;
+  ecore_imf_evas_event_key_down_wrap(event, &imf_event.key_down);
+  return ecore_imf_context_filter_event(imf_context_, ECORE_IMF_EVENT_KEY_DOWN,
+                                        &imf_event);
 }
 
 bool TizenInputMethodContext::HandleEvasEventKeyUp(Evas_Event_Key_Up* event) {
-  Ecore_IMF_Event_Key_Up imf_event;
-  ecore_imf_evas_event_key_up_wrap(event, &imf_event);
-
-  return ecore_imf_context_filter_event(
-      imf_context_, ECORE_IMF_EVENT_KEY_UP,
-      reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+  Ecore_IMF_Event imf_event;
+  ecore_imf_evas_event_key_up_wrap(event, &imf_event.key_up);
+  return ecore_imf_context_filter_event(imf_context_, ECORE_IMF_EVENT_KEY_UP,
+                                        &imf_event);
 }
 
 #ifdef NUI_SUPPORT
@@ -226,18 +222,17 @@ bool TizenInputMethodContext::HandleNuiKeyEvent(const char* device_name,
         event.dev, static_cast<Ecore_IMF_Device_Subclass>(device_subclass));
   }
 
+  Ecore_IMF_Event imf_event;
   if (is_down) {
-    Ecore_IMF_Event_Key_Down imf_event =
+    imf_event.key_down =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Down>(&event);
-    return ecore_imf_context_filter_event(
-        imf_context_, ECORE_IMF_EVENT_KEY_DOWN,
-        reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+    return ecore_imf_context_filter_event(imf_context_,
+                                          ECORE_IMF_EVENT_KEY_DOWN, &imf_event);
   } else {
-    Ecore_IMF_Event_Key_Up imf_event =
+    imf_event.key_up =
         EcoreEventKeyToEcoreImfEvent<Ecore_IMF_Event_Key_Up>(&event);
-    return ecore_imf_context_filter_event(
-        imf_context_, ECORE_IMF_EVENT_KEY_UP,
-        reinterpret_cast<Ecore_IMF_Event*>(&imf_event));
+    return ecore_imf_context_filter_event(imf_context_, ECORE_IMF_EVENT_KEY_UP,
+                                          &imf_event);
   }
 }
 #endif

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -105,7 +105,7 @@ void TizenViewElementary::DestroyView() {
 void TizenViewElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_RESIZE] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenViewElementary*>(data);
+        auto* self = static_cast<TizenViewElementary*>(data);
         if (self->view_delegate_) {
           if (self->container_ == object) {
             int32_t width = 0, height = 0;
@@ -127,7 +127,7 @@ void TizenViewElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_DOWN] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenViewElementary*>(data);
+        auto* self = static_cast<TizenViewElementary*>(data);
         if (self->view_delegate_) {
           if (self->container_ == object) {
             auto* mouse_event =
@@ -147,7 +147,7 @@ void TizenViewElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_UP] = [](void* data, Evas* evas,
                                                       Evas_Object* object,
                                                       void* event_info) {
-    auto* self = reinterpret_cast<TizenViewElementary*>(data);
+    auto* self = static_cast<TizenViewElementary*>(data);
     if (self->view_delegate_) {
       if (self->container_ == object) {
         auto* mouse_event = reinterpret_cast<Evas_Event_Mouse_Up*>(event_info);
@@ -170,7 +170,7 @@ void TizenViewElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_MOVE] = [](void* data, Evas* evas,
                                                         Evas_Object* object,
                                                         void* event_info) {
-    auto* self = reinterpret_cast<TizenViewElementary*>(data);
+    auto* self = static_cast<TizenViewElementary*>(data);
     if (self->view_delegate_) {
       if (self->container_ == object) {
         auto* mouse_event =
@@ -195,7 +195,7 @@ void TizenViewElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_WHEEL] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenViewElementary*>(data);
+        auto* self = static_cast<TizenViewElementary*>(data);
         if (self->view_delegate_) {
           if (self->container_ == object) {
             auto* wheel_event =
@@ -223,7 +223,7 @@ void TizenViewElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN] = [](void* data, Evas* evas,
                                                       Evas_Object* object,
                                                       void* event_info) {
-    auto* self = reinterpret_cast<TizenViewElementary*>(data);
+    auto* self = static_cast<TizenViewElementary*>(data);
     if (self->view_delegate_) {
       if (self->container_ == object && self->focused_) {
         auto* key_event = reinterpret_cast<Evas_Event_Key_Down*>(event_info);
@@ -249,7 +249,7 @@ void TizenViewElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenViewElementary*>(data);
+        auto* self = static_cast<TizenViewElementary*>(data);
         if (self->view_delegate_) {
           if (self->container_ == object && self->focused_) {
             auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
@@ -274,7 +274,7 @@ void TizenViewElementary::RegisterEventHandlers() {
                                  this);
 
   focused_callback_ = [](void* data, Evas_Object* object, void* event_info) {
-    auto* self = reinterpret_cast<TizenViewElementary*>(data);
+    auto* self = static_cast<TizenViewElementary*>(data);
     if (self->view_delegate_) {
       if (self->container_ == object) {
         self->focused_ = true;

--- a/flutter/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/flutter/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -66,7 +66,7 @@ void TizenVsyncWaiter::SendMessage(int event, intptr_t baton) {
 }
 
 void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
-  auto* self = reinterpret_cast<TizenVsyncWaiter*>(data);
+  auto* self = static_cast<TizenVsyncWaiter*>(data);
 
   std::weak_ptr<TdmClient> tdm_client = self->tdm_client_;
   if (!tdm_client.lock()->IsValid()) {
@@ -166,7 +166,7 @@ void TdmClient::VblankCallback(tdm_client_vblank* vblank,
                                unsigned int tv_sec,
                                unsigned int tv_usec,
                                void* user_data) {
-  auto* self = reinterpret_cast<TdmClient*>(user_data);
+  auto* self = static_cast<TdmClient*>(user_data);
   FT_ASSERT(self != nullptr);
 
   std::lock_guard<std::mutex> lock(self->engine_mutex_);

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -190,7 +190,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_WL2_EVENT_WINDOW_ROTATE,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* rotation_event =
               reinterpret_cast<Ecore_Wl2_Event_Window_Rotation*>(event);
@@ -211,7 +211,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_WL2_EVENT_WINDOW_CONFIGURE,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* configure_event =
               reinterpret_cast<Ecore_Wl2_Event_Window_Configure*>(event);
@@ -234,7 +234,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_MOUSE_BUTTON_DOWN,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* button_event =
               reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
@@ -252,7 +252,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_MOUSE_BUTTON_UP,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* button_event =
               reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
@@ -270,7 +270,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_MOUSE_MOVE,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
           if (move_event->window == self->GetWindowId()) {
@@ -287,7 +287,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_MOUSE_WHEEL,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* wheel_event = reinterpret_cast<Ecore_Event_Mouse_Wheel*>(event);
           if (wheel_event->window == self->GetWindowId()) {
@@ -314,7 +314,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_KEY_DOWN,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* key_event = reinterpret_cast<Ecore_Event_Key*>(event);
           if (key_event->window == self->GetWindowId()) {
@@ -338,7 +338,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
   ecore_event_handlers_.push_back(ecore_event_handler_add(
       ECORE_EVENT_KEY_UP,
       [](void* data, int type, void* event) -> Eina_Bool {
-        auto* self = reinterpret_cast<TizenWindowEcoreWl2*>(data);
+        auto* self = static_cast<TizenWindowEcoreWl2*>(data);
         if (self->view_delegate_) {
           auto* key_event = reinterpret_cast<Ecore_Event_Key*>(event);
           if (key_event->window == self->GetWindowId()) {

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -162,7 +162,7 @@ void TizenWindowElementary::SetWindowOptions() {
 void TizenWindowElementary::RegisterEventHandlers() {
   rotation_changed_callback_ = [](void* data, Evas_Object* object,
                                   void* event_info) {
-    auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+    auto* self = static_cast<TizenWindowElementary*>(data);
     if (self->view_delegate_) {
       if (self->elm_win_ == object) {
         self->view_delegate_->OnRotate(self->GetRotation());
@@ -175,7 +175,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_RESIZE] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+        auto* self = static_cast<TizenWindowElementary*>(data);
         if (self->view_delegate_) {
           if (self->elm_win_ == object) {
             int32_t x = 0, y = 0, width = 0, height = 0;
@@ -194,7 +194,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_DOWN] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+        auto* self = static_cast<TizenWindowElementary*>(data);
         if (self->view_delegate_) {
           if (self->image_ == object) {
             auto* mouse_event =
@@ -213,7 +213,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_UP] = [](void* data, Evas* evas,
                                                       Evas_Object* object,
                                                       void* event_info) {
-    auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+    auto* self = static_cast<TizenWindowElementary*>(data);
     if (self->view_delegate_) {
       if (self->image_ == object) {
         auto* mouse_event = reinterpret_cast<Evas_Event_Mouse_Up*>(event_info);
@@ -230,7 +230,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_MOVE] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+        auto* self = static_cast<TizenWindowElementary*>(data);
         if (self->view_delegate_) {
           if (self->image_ == object) {
             auto* mouse_event =
@@ -248,7 +248,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_MOUSE_WHEEL] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+        auto* self = static_cast<TizenWindowElementary*>(data);
         if (self->view_delegate_) {
           if (self->image_ == object) {
             auto* wheel_event =
@@ -276,7 +276,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
   evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN] = [](void* data, Evas* evas,
                                                       Evas_Object* object,
                                                       void* event_info) {
-    auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+    auto* self = static_cast<TizenWindowElementary*>(data);
     if (self->view_delegate_) {
       if (self->elm_win_ == object) {
         auto* key_event = reinterpret_cast<Evas_Event_Key_Down*>(event_info);
@@ -300,7 +300,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
 
   evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
       [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = reinterpret_cast<TizenWindowElementary*>(data);
+        auto* self = static_cast<TizenWindowElementary*>(data);
         if (self->view_delegate_) {
           if (self->elm_win_ == object) {
             auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
@@ -395,9 +395,8 @@ uintptr_t TizenWindowElementary::GetWindowId() {
 
 void TizenWindowElementary::SetPreferredOrientations(
     const std::vector<int>& rotations) {
-  elm_win_wm_rotation_available_rotations_set(
-      elm_win_, reinterpret_cast<const int*>(rotations.data()),
-      rotations.size());
+  elm_win_wm_rotation_available_rotations_set(elm_win_, rotations.data(),
+                                              rotations.size());
 }
 
 void TizenWindowElementary::BindKeys(const std::vector<std::string>& keys) {


### PR DESCRIPTION
Variables whose types can be known at compile time should be converted using `static_cast`.