### PR TITLE
Add dirty region management

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -450,12 +450,22 @@ FlutterRendererConfig FlutterTizenEngine::GetRendererConfig() {
       }
       return engine->view()->OnClearCurrent();
     };
-    config.open_gl.present = [](void* user_data) -> bool {
+    config.open_gl.fbo_reset_after_present = true;
+    config.open_gl.present_with_info =
+        [](void* user_data, const FlutterPresentInfo* info) -> bool {
       auto* engine = static_cast<FlutterTizenEngine*>(user_data);
       if (!engine->view()) {
         return false;
       }
-      return engine->view()->OnPresent();
+      return engine->view()->OnPresent(info);
+    };
+    config.open_gl.populate_existing_damage =
+        [](void* user_data, const intptr_t fbo_id,
+           FlutterDamage* existing_damage) -> void {
+      auto* engine = static_cast<FlutterTizenEngine*>(user_data);
+      if (engine->view()) {
+        engine->view()->OnPopulateExistingDamage(fbo_id, existing_damage);
+      }
     };
     config.open_gl.fbo_callback = [](void* user_data) -> uint32_t {
       auto* engine = static_cast<FlutterTizenEngine*>(user_data);

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -131,8 +131,8 @@ bool FlutterTizenView::OnMakeResourceCurrent() {
   return engine_->renderer()->OnMakeResourceCurrent();
 }
 
-bool FlutterTizenView::OnPresent() {
-  bool result = engine_->renderer()->OnPresent();
+bool FlutterTizenView::OnPresent(const FlutterPresentInfo* info) {
+  bool result = engine_->renderer()->OnPresent(info);
 #ifdef NUI_SUPPORT
   if (auto* nui_view =
           dynamic_cast<flutter::TizenViewNui*>(tizen_view_.get())) {
@@ -140,6 +140,21 @@ bool FlutterTizenView::OnPresent() {
   }
 #endif
   return result;
+}
+
+void FlutterTizenView::OnPopulateExistingDamage(
+    const intptr_t fbo_id,
+    FlutterDamage* existing_damage) {
+#ifndef WEARABLE_PROFILE
+  if (auto* renderer = dynamic_cast<TizenRendererEgl*>(engine_->renderer())) {
+    // TODO(swift-kim): Disable partial repaint if the input panel is shown?
+    // if (!tizen_view_->input_method_context()->IsInputPanelShown()) {
+    renderer->PopulateExistingDamage(fbo_id, existing_damage);
+    // }
+  }
+#endif
+  // Otherwise do full repaint.
+  existing_damage->num_rects = 0;
 }
 
 uint32_t FlutterTizenView::OnGetFBO() {

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -48,8 +48,10 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   bool OnMakeCurrent();
   bool OnClearCurrent();
   bool OnMakeResourceCurrent();
-  bool OnPresent();
+  bool OnPresent(const FlutterPresentInfo* info);
 
+  void OnPopulateExistingDamage(const intptr_t fbo_id,
+                                FlutterDamage* existing_damage);
   uint32_t OnGetFBO();
 
   void* OnProcResolver(const char* name);

--- a/flutter/shell/platform/tizen/tizen_renderer.h
+++ b/flutter/shell/platform/tizen/tizen_renderer.h
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+#include "flutter/shell/platform/embedder/embedder.h"
+
 namespace flutter {
 
 class TizenRenderer {
@@ -30,7 +32,7 @@ class TizenRenderer {
 
   virtual bool OnMakeResourceCurrent() = 0;
 
-  virtual bool OnPresent() = 0;
+  virtual bool OnPresent(const FlutterPresentInfo* info) = 0;
 
   virtual uint32_t OnGetFBO() = 0;
 

--- a/flutter/shell/platform/tizen/tizen_renderer_egl.h
+++ b/flutter/shell/platform/tizen/tizen_renderer_egl.h
@@ -6,9 +6,14 @@
 #define EMBEDDER_TIZEN_RENDERER_EGL_H_
 
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 
+#include <array>
+#include <list>
 #include <string>
+#include <unordered_map>
 
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/tizen_renderer.h"
 
 namespace flutter {
@@ -32,7 +37,7 @@ class TizenRendererEgl : public TizenRenderer {
 
   bool OnMakeResourceCurrent() override;
 
-  bool OnPresent() override;
+  bool OnPresent(const FlutterPresentInfo* info) override;
 
   uint32_t OnGetFBO() override;
 
@@ -42,10 +47,17 @@ class TizenRendererEgl : public TizenRenderer {
 
   void ResizeSurface(int32_t width, int32_t height) override;
 
+  void PopulateExistingDamage(const intptr_t fbo_id,
+                              FlutterDamage* existing_damage);
+
  private:
   bool ChooseEGLConfiguration();
 
   void PrintEGLError();
+
+  // Auxiliary function used to transform a FlutterRect into the format that is
+  // expected by the EGL functions (i.e. array of EGLint).
+  std::array<EGLint, 4> RectToInts(const FlutterRect rect);
 
   EGLConfig egl_config_ = nullptr;
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;
@@ -53,8 +65,17 @@ class TizenRendererEgl : public TizenRenderer {
   EGLSurface egl_surface_ = EGL_NO_SURFACE;
   EGLContext egl_resource_context_ = EGL_NO_CONTEXT;
   EGLSurface egl_resource_surface_ = EGL_NO_SURFACE;
-
   std::string egl_extension_str_;
+
+  PFNEGLSETDAMAGEREGIONKHRPROC egl_set_damage_region_ = nullptr;
+  PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC egl_swap_buffers_with_damage_ = nullptr;
+
+  // Keeps track of the most recent frame damages so that existing damage can
+  // be easily computed.
+  std::list<FlutterRect> damage_history_;
+
+  // Keeps track of the existing damage associated with each FBO ID.
+  std::unordered_map<intptr_t, FlutterRect*> existing_damage_map_;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_renderer_evas_gl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_evas_gl.cc
@@ -76,7 +76,6 @@ bool TizenRendererEvasGL::CreateSurface(void* render_target,
   OnMakeCurrent();
   glClearColor(0, 0, 0, 0);
   glClear(GL_COLOR_BUFFER_BIT);
-  OnPresent();
 
   return true;
 }
@@ -130,11 +129,10 @@ bool TizenRendererEvasGL::OnMakeResourceCurrent() {
   return true;
 }
 
-bool TizenRendererEvasGL::OnPresent() {
+bool TizenRendererEvasGL::OnPresent(const FlutterPresentInfo* info) {
   if (!IsValid()) {
     return false;
   }
-
   return true;
 }
 

--- a/flutter/shell/platform/tizen/tizen_renderer_evas_gl.h
+++ b/flutter/shell/platform/tizen/tizen_renderer_evas_gl.h
@@ -9,6 +9,7 @@
 
 #include <Elementary.h>
 
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/tizen_renderer.h"
 
 namespace flutter {
@@ -34,7 +35,7 @@ class TizenRendererEvasGL : public TizenRenderer {
 
   bool OnMakeResourceCurrent() override;
 
-  bool OnPresent() override;
+  bool OnPresent(const FlutterPresentInfo* info) override;
 
   uint32_t OnGetFBO() override;
 


### PR DESCRIPTION
This is just a draft PR for code sharing. I referenced [this GLFW example](https://github.com/flutter/engine/commit/33fccf5649735bd8c449def276a158b995602cc9) in the engine repo. If anyone is interested, please improve this code to fully implement partial repaint. I'll close this PR soon.

Known issue: Visual artifacts are generated when the software keyboard is open on TV devices.

Checklist:
- [x] Verify with not supported renderer (Evas GL) - [this engine change](https://github.com/swift-kim/engine/commit/20c24110038ecfd6f5d410d886bd3d79ec07d97b) is required.
- [ ] Verify with texture-based plugins (e.g. video_player).
- [x] Verify with NUIFlutterView ([add-to-app](https://github.com/flutter-tizen/flutter-tizen/wiki/Adding-to-existing-app) scenario).
- [ ] Verify with any other corner cases.

For most apps, you will see only limited performance improvements by applying this. However, for an app with a complex UI and scrolling on parts of the screen (Gallery), there was a significant improvement in frame rate (up to 20 fps) when scrolling the scrollable widget.