### PR TITLE
[ci] Downgrade LLVM 14 to 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           src/tools/gn \
             --target-cpu ${{ matrix.arch }} \
-            --target-toolchain /usr/lib/llvm-14 \
+            --target-toolchain /usr/lib/llvm-12 \
             --target-dir build
           ninja -C src/out/build
 
@@ -62,7 +62,7 @@ jobs:
         run: |
           src/tools/gn \
             --target-cpu ${{ matrix.arch }} \
-            --target-toolchain /usr/lib/llvm-14 \
+            --target-toolchain /usr/lib/llvm-12 \
             --target-sysroot src/sysroot-6.5/${{ matrix.arch }} \
             --api-version 6.5 --system-cxx \
             --target-dir build


### PR DESCRIPTION
Fixes https://github.com/flutter-tizen/embedder/issues/26.

Note that we can't do this for the engine repo because the engine build requires LLVM 15. If you are our contributor and want to debug the Flutter engine but not the embedder, you shouldn't use `flutter-tizen-gdb` and instead do local debugging with GDB or LLVM in the sdb shell on a rooted device or emulator.
