### PR TITLE
Handle right and middle mouse button clicks

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -204,6 +204,7 @@ template("embedder") {
       "//flutter/shell/platform/common:common_cpp_input",
       "//flutter/shell/platform/common:common_cpp_library_headers",
       "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+      "//flutter/shell/platform/embedder:embedder_headers",
       "//third_party/rapidjson",
     ]
 

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -8,6 +8,7 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/flutter_project_bundle.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_view.h"
@@ -251,19 +252,18 @@ void FlutterDesktopViewOnPointerEvent(FlutterDesktopViewRef view,
                                       double y,
                                       size_t timestamp,
                                       int32_t device_id) {
+  // TODO(swift-kim): Support right and middle button clicks.
+  FlutterPointerMouseButtons button = kFlutterPointerButtonMousePrimary;
   switch (type) {
     case FlutterDesktopPointerEventType::kMouseDown:
     default:
-      ViewFromHandle(view)->OnPointerDown(
-          x, y, timestamp, kFlutterPointerDeviceKindTouch, device_id);
+      ViewFromHandle(view)->OnPointerDown(x, y, button, timestamp, device_id);
       break;
     case FlutterDesktopPointerEventType::kMouseUp:
-      ViewFromHandle(view)->OnPointerUp(
-          x, y, timestamp, kFlutterPointerDeviceKindTouch, device_id);
+      ViewFromHandle(view)->OnPointerUp(x, y, button, timestamp, device_id);
       break;
     case FlutterDesktopPointerEventType::kMouseMove:
-      ViewFromHandle(view)->OnPointerMove(
-          x, y, timestamp, kFlutterPointerDeviceKindTouch, device_id);
+      ViewFromHandle(view)->OnPointerMove(x, y, timestamp, device_id);
       break;
   }
 }

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -252,18 +252,23 @@ void FlutterDesktopViewOnPointerEvent(FlutterDesktopViewRef view,
                                       double y,
                                       size_t timestamp,
                                       int32_t device_id) {
-  // TODO(swift-kim): Support right and middle button clicks.
+  // TODO(swift-kim): Add support for mouse devices.
+  FlutterPointerDeviceKind device_kind = kFlutterPointerDeviceKindTouch;
   FlutterPointerMouseButtons button = kFlutterPointerButtonMousePrimary;
+
   switch (type) {
     case FlutterDesktopPointerEventType::kMouseDown:
     default:
-      ViewFromHandle(view)->OnPointerDown(x, y, button, timestamp, device_id);
+      ViewFromHandle(view)->OnPointerDown(x, y, button, timestamp, device_kind,
+                                          device_id);
       break;
     case FlutterDesktopPointerEventType::kMouseUp:
-      ViewFromHandle(view)->OnPointerUp(x, y, button, timestamp, device_id);
+      ViewFromHandle(view)->OnPointerUp(x, y, button, timestamp, device_kind,
+                                        device_id);
       break;
     case FlutterDesktopPointerEventType::kMouseMove:
-      ViewFromHandle(view)->OnPointerMove(x, y, timestamp, device_id);
+      ViewFromHandle(view)->OnPointerMove(x, y, timestamp, device_kind,
+                                          device_id);
       break;
   }
 }

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -409,8 +409,7 @@ void FlutterTizenView::SendFlutterPointerEvent(FlutterPointerPhase phase,
     event.buttons = 0;
     event.timestamp = timestamp * 1000;
     event.device = state->device_id;
-    event.device_kind = state->device_kind;
-    event.buttons = state->buttons;
+    event.device_kind = kFlutterPointerDeviceKindTouch;
     engine_->SendPointerEvent(event);
 
     state->flutter_state_is_added = true;
@@ -428,9 +427,17 @@ void FlutterTizenView::SendFlutterPointerEvent(FlutterPointerPhase phase,
   event.scroll_delta_y = delta_y * kScrollOffsetMultiplier;
   event.timestamp = timestamp * 1000;
   event.device = state->device_id;
-  event.device_kind = state->device_kind;
-  event.buttons = state->buttons;
-
+  // Assume the "touch" device type if only the left button is pressed.
+  // This assumption is made because the platform doesn't provide exact device
+  // type information.
+  // Note that touch and mouse have different scroll behaviors:
+  // https://docs.flutter.dev/release/breaking-changes/default-scroll-behavior-drag
+  if (state->buttons == kFlutterPointerButtonMousePrimary) {
+    event.device_kind = kFlutterPointerDeviceKindTouch;
+  } else {
+    event.device_kind = kFlutterPointerDeviceKindMouse;
+    event.buttons = state->buttons;
+  }
   engine_->SendPointerEvent(event);
 }
 

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -45,7 +45,9 @@ const std::vector<std::string> kBindableSystemKeys = {
     "XF86Exit",
 };
 
-constexpr int32_t kScrollOffsetMultiplier = 20;
+// The multiplier is taken from the Chromium source
+// (ui/events/x/events_x_utils.cc).
+constexpr int32_t kScrollOffsetMultiplier = 53;
 
 }  // namespace
 

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -45,6 +45,8 @@ const std::vector<std::string> kBindableSystemKeys = {
     "XF86Exit",
 };
 
+constexpr int32_t kScrollOffsetMultiplier = 20;
+
 }  // namespace
 
 namespace flutter {
@@ -200,46 +202,80 @@ void FlutterTizenView::OnRotate(int32_t degree) {
   SendWindowMetrics(geometry.left, geometry.top, width, height, 0.0);
 }
 
+FlutterTizenView::PointerState* FlutterTizenView::GetOrCreatePointerState(
+    int32_t device_id) {
+  auto [iter, added] = pointer_states_.try_emplace(device_id, nullptr);
+  if (added) {
+    auto state = std::make_unique<PointerState>();
+    state->device_id = device_id;
+    iter->second = std::move(state);
+  }
+  return iter->second.get();
+}
+
+FlutterPointerPhase FlutterTizenView::GetPointerPhaseFromState(
+    const PointerState* state) const {
+  // For details about this logic, see FlutterPointerPhase in the embedder.h
+  // file.
+  if (state->buttons == 0) {
+    return state->flutter_state_is_down ? FlutterPointerPhase::kUp
+                                        : FlutterPointerPhase::kHover;
+  } else {
+    return state->flutter_state_is_down ? FlutterPointerPhase::kMove
+                                        : FlutterPointerPhase::kDown;
+  }
+}
+
 void FlutterTizenView::OnPointerMove(double x,
                                      double y,
                                      size_t timestamp,
-                                     FlutterPointerDeviceKind device_kind,
                                      int32_t device_id) {
-  if (pointer_state_) {
-    SendFlutterPointerEvent(kMove, x, y, 0, 0, timestamp, device_kind,
-                            device_id);
-  }
+  PointerState* state = GetOrCreatePointerState(device_id);
+  FlutterPointerPhase phase = GetPointerPhaseFromState(state);
+  SendFlutterPointerEvent(phase, x, y, 0, 0, timestamp, state);
 }
 
 void FlutterTizenView::OnPointerDown(double x,
                                      double y,
+                                     FlutterPointerMouseButtons button,
                                      size_t timestamp,
-                                     FlutterPointerDeviceKind device_kind,
                                      int32_t device_id) {
-  pointer_state_ = true;
-  SendFlutterPointerEvent(kDown, x, y, 0, 0, timestamp, device_kind, device_id);
+  if (button != 0) {
+    PointerState* state = GetOrCreatePointerState(device_id);
+    state->buttons |= button;
+    FlutterPointerPhase phase = GetPointerPhaseFromState(state);
+    SendFlutterPointerEvent(phase, x, y, 0, 0, timestamp, state);
+
+    state->flutter_state_is_down = true;
+  }
 }
 
 void FlutterTizenView::OnPointerUp(double x,
                                    double y,
+                                   FlutterPointerMouseButtons button,
                                    size_t timestamp,
-                                   FlutterPointerDeviceKind device_kind,
                                    int32_t device_id) {
-  pointer_state_ = false;
-  SendFlutterPointerEvent(kUp, x, y, 0, 0, timestamp, device_kind, device_id);
+  if (button != 0) {
+    PointerState* state = GetOrCreatePointerState(device_id);
+    state->buttons &= ~button;
+    FlutterPointerPhase phase = GetPointerPhaseFromState(state);
+    SendFlutterPointerEvent(phase, x, y, 0, 0, timestamp, state);
+
+    if (phase == FlutterPointerPhase::kUp) {
+      state->flutter_state_is_down = false;
+    }
+  }
 }
 
 void FlutterTizenView::OnScroll(double x,
                                 double y,
                                 double delta_x,
                                 double delta_y,
-                                int scroll_offset_multiplier,
                                 size_t timestamp,
-                                FlutterPointerDeviceKind device_kind,
                                 int32_t device_id) {
-  SendFlutterPointerEvent(
-      pointer_state_ ? kMove : kHover, x, y, delta_x * scroll_offset_multiplier,
-      delta_y * scroll_offset_multiplier, timestamp, device_kind, device_id);
+  PointerState* state = GetOrCreatePointerState(device_id);
+  FlutterPointerPhase phase = GetPointerPhaseFromState(state);
+  SendFlutterPointerEvent(phase, x, y, delta_x, delta_y, timestamp, state);
 }
 
 void FlutterTizenView::OnKey(const char* key,
@@ -341,15 +377,13 @@ void FlutterTizenView::SendWindowMetrics(int32_t left,
   engine_->SendWindowMetrics(left, top, width, height, computed_pixel_ratio);
 }
 
-void FlutterTizenView::SendFlutterPointerEvent(
-    FlutterPointerPhase phase,
-    double x,
-    double y,
-    double delta_x,
-    double delta_y,
-    size_t timestamp,
-    FlutterPointerDeviceKind device_kind,
-    int device_id) {
+void FlutterTizenView::SendFlutterPointerEvent(FlutterPointerPhase phase,
+                                               double x,
+                                               double y,
+                                               double delta_x,
+                                               double delta_y,
+                                               size_t timestamp,
+                                               PointerState* state) {
   TizenGeometry geometry = tizen_view_->GetGeometry();
   double new_x = x, new_y = y;
 
@@ -364,6 +398,24 @@ void FlutterTizenView::SendFlutterPointerEvent(
     new_y = geometry.width - x;
   }
 
+  // If the pointer isn't already added, synthesize an add to satisfy Flutter's
+  // expectations about events.
+  if (!state->flutter_state_is_added) {
+    FlutterPointerEvent event = {};
+    event.struct_size = sizeof(event);
+    event.phase = FlutterPointerPhase::kAdd;
+    event.x = new_x;
+    event.y = new_y;
+    event.buttons = 0;
+    event.timestamp = timestamp * 1000;
+    event.device = state->device_id;
+    event.device_kind = state->device_kind;
+    event.buttons = state->buttons;
+    engine_->SendPointerEvent(event);
+
+    state->flutter_state_is_added = true;
+  }
+
   FlutterPointerEvent event = {};
   event.struct_size = sizeof(event);
   event.phase = phase;
@@ -372,11 +424,12 @@ void FlutterTizenView::SendFlutterPointerEvent(
   if (delta_x != 0 || delta_y != 0) {
     event.signal_kind = kFlutterPointerSignalKindScroll;
   }
-  event.scroll_delta_x = delta_x;
-  event.scroll_delta_y = delta_y;
+  event.scroll_delta_x = delta_x * kScrollOffsetMultiplier;
+  event.scroll_delta_y = delta_y * kScrollOffsetMultiplier;
   event.timestamp = timestamp * 1000;
-  event.device = device_id;
-  event.device_kind = kFlutterPointerDeviceKindTouch;
+  event.device = state->device_id;
+  event.device_kind = state->device_kind;
+  event.buttons = state->buttons;
 
   engine_->SendPointerEvent(event);
 }

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -113,9 +113,6 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // track of which buttons have been pressed, so it's the embedder's
   // responsibility.
   struct PointerState {
-    // The device kind.
-    FlutterPointerDeviceKind device_kind = kFlutterPointerDeviceKindMouse;
-
     // The device ID.
     int32_t device_id = 0;
 

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -64,18 +64,21 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   void OnPointerMove(double x,
                      double y,
                      size_t timestamp,
+                     FlutterPointerDeviceKind device_kind,
                      int32_t device_id) override;
 
   void OnPointerDown(double x,
                      double y,
                      FlutterPointerMouseButtons button,
                      size_t timestamp,
+                     FlutterPointerDeviceKind device_kind,
                      int32_t device_id) override;
 
   void OnPointerUp(double x,
                    double y,
                    FlutterPointerMouseButtons button,
                    size_t timestamp,
+                   FlutterPointerDeviceKind device_kind,
                    int32_t device_id) override;
 
   void OnScroll(double x,
@@ -83,6 +86,7 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
                 double delta_x,
                 double delta_y,
                 size_t timestamp,
+                FlutterPointerDeviceKind device_kind,
                 int32_t device_id) override;
 
   void OnKey(const char* key,
@@ -113,8 +117,11 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // track of which buttons have been pressed, so it's the embedder's
   // responsibility.
   struct PointerState {
-    // The device ID.
-    int32_t device_id = 0;
+    // The device kind.
+    FlutterPointerDeviceKind device_kind = kFlutterPointerDeviceKindTouch;
+
+    // A virtual pointer ID that is unique across all device kinds.
+    int32_t pointer_id = 0;
 
     // True if the last event sent to Flutter had at least one button pressed.
     bool flutter_state_is_down = false;
@@ -129,7 +136,8 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   };
 
   // Creates a PointerState object unless it already exists.
-  PointerState* GetOrCreatePointerState(int32_t device_id);
+  PointerState* GetOrCreatePointerState(FlutterPointerDeviceKind device_kind,
+                                        int32_t device_id);
 
   // Returns a FlutterPointerPhase corresponding to the current pointer state.
   FlutterPointerPhase GetPointerPhaseFromState(const PointerState* state) const;

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -64,28 +64,25 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   void OnPointerMove(double x,
                      double y,
                      size_t timestamp,
-                     FlutterPointerDeviceKind device_kind,
                      int32_t device_id) override;
 
   void OnPointerDown(double x,
                      double y,
+                     FlutterPointerMouseButtons button,
                      size_t timestamp,
-                     FlutterPointerDeviceKind device_kind,
                      int32_t device_id) override;
 
   void OnPointerUp(double x,
                    double y,
+                   FlutterPointerMouseButtons button,
                    size_t timestamp,
-                   FlutterPointerDeviceKind device_kind,
                    int32_t device_id) override;
 
   void OnScroll(double x,
                 double y,
                 double delta_x,
                 double delta_y,
-                int scroll_offset_multiplier,
                 size_t timestamp,
-                FlutterPointerDeviceKind device_kind,
                 int32_t device_id) override;
 
   void OnKey(const char* key,
@@ -112,6 +109,34 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   TextInputChannel* text_input_channel() { return text_input_channel_.get(); }
 
  private:
+  // Struct holding the state of an individual pointer. The engine doesn't keep
+  // track of which buttons have been pressed, so it's the embedder's
+  // responsibility.
+  struct PointerState {
+    // The device kind.
+    FlutterPointerDeviceKind device_kind = kFlutterPointerDeviceKindMouse;
+
+    // The device ID.
+    int32_t device_id = 0;
+
+    // True if the last event sent to Flutter had at least one button pressed.
+    bool flutter_state_is_down = false;
+
+    // True if kAdd has been sent to Flutter. Used to determine whether
+    // to send a kAdd event before sending an incoming pointer event, since
+    // Flutter expects pointers to be added before events are sent for them.
+    bool flutter_state_is_added = false;
+
+    // The currently pressed buttons, as represented in FlutterPointerEvent.
+    uint64_t buttons = 0;
+  };
+
+  // Creates a PointerState object unless it already exists.
+  PointerState* GetOrCreatePointerState(int32_t device_id);
+
+  // Returns a FlutterPointerPhase corresponding to the current pointer state.
+  FlutterPointerPhase GetPointerPhaseFromState(const PointerState* state) const;
+
   // Sends a window metrics update to the Flutter engine using current window
   // dimensions in physical.
   void SendWindowMetrics(int32_t left,
@@ -127,14 +152,16 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
                                double delta_x,
                                double delta_y,
                                size_t timestamp,
-                               FlutterPointerDeviceKind device_kind,
-                               int device_id);
+                               PointerState* state);
 
   // The engine associated with this view.
   std::unique_ptr<FlutterTizenEngine> engine_;
 
   // The platform view associated with this Flutter view.
   std::unique_ptr<TizenViewBase> tizen_view_;
+
+  // Keeps track of pointer states.
+  std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;
 
   // The plugin registrar managing internal plugins.
   std::unique_ptr<PluginRegistrar> internal_plugin_registrar_;
@@ -150,9 +177,6 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
 
   // The current view rotation degree.
   int32_t rotation_degree_ = 0;
-
-  // The current pointer state to distinguish move or hover event.
-  bool pointer_state_ = false;
 
   // The current view transformation.
   FlutterTransformation flutter_transformation_ = {1.0, 0.0, 0.0, 0.0, 1.0,

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -27,6 +27,17 @@ FlutterPointerMouseButtons ToFlutterPointerButton(int32_t button) {
   }
 }
 
+FlutterPointerDeviceKind ToFlutterDeviceKind(const Evas_Device* dev) {
+  Evas_Device_Class device_class = evas_device_class_get(dev);
+  if (device_class == EVAS_DEVICE_CLASS_MOUSE) {
+    return kFlutterPointerDeviceKindMouse;
+  } else if (device_class == EVAS_DEVICE_CLASS_PEN) {
+    return kFlutterPointerDeviceKindStylus;
+  } else {
+    return kFlutterPointerDeviceKindTouch;
+  }
+}
+
 uint32_t EvasModifierToEcoreEventModifiers(const Evas_Modifier* evas_modifier) {
   uint32_t modifiers = 0;
   if (evas_key_modifier_is_set(evas_modifier, "Control")) {
@@ -134,23 +145,23 @@ void TizenViewElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_RESIZE],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_MOUSE_DOWN] = [](void* data, Evas* evas,
-                                                        Evas_Object* object,
-                                                        void* event_info) {
-    auto* self = static_cast<TizenViewElementary*>(data);
-    if (self->view_delegate_) {
-      if (self->container_ == object) {
-        auto* mouse_event =
-            reinterpret_cast<Evas_Event_Mouse_Down*>(event_info);
-        TizenGeometry geometry = self->GetGeometry();
-        self->view_delegate_->OnPointerDown(
-            mouse_event->canvas.x - geometry.left,
-            mouse_event->canvas.y - geometry.top,
-            ToFlutterPointerButton(mouse_event->button), mouse_event->timestamp,
-            reinterpret_cast<intptr_t>(mouse_event->dev));
-      }
-    }
-  };
+  evas_object_callbacks_[EVAS_CALLBACK_MOUSE_DOWN] =
+      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
+        auto* self = static_cast<TizenViewElementary*>(data);
+        if (self->view_delegate_) {
+          if (self->container_ == object) {
+            auto* mouse_event =
+                reinterpret_cast<Evas_Event_Mouse_Down*>(event_info);
+            TizenGeometry geometry = self->GetGeometry();
+            self->view_delegate_->OnPointerDown(
+                mouse_event->canvas.x - geometry.left,
+                mouse_event->canvas.y - geometry.top,
+                ToFlutterPointerButton(mouse_event->button),
+                mouse_event->timestamp, ToFlutterDeviceKind(mouse_event->dev),
+                reinterpret_cast<intptr_t>(mouse_event->dev));
+          }
+        }
+      };
   evas_object_event_callback_add(
       container_, EVAS_CALLBACK_MOUSE_DOWN,
       evas_object_callbacks_[EVAS_CALLBACK_MOUSE_DOWN], this);
@@ -171,6 +182,7 @@ void TizenViewElementary::RegisterEventHandlers() {
             mouse_event->canvas.x - geometry.left,
             mouse_event->canvas.y - geometry.top,
             ToFlutterPointerButton(mouse_event->button), mouse_event->timestamp,
+            ToFlutterDeviceKind(mouse_event->dev),
             reinterpret_cast<intptr_t>(mouse_event->dev));
       }
     }
@@ -179,29 +191,29 @@ void TizenViewElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_MOUSE_UP],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_MOUSE_MOVE] = [](void* data, Evas* evas,
-                                                        Evas_Object* object,
-                                                        void* event_info) {
-    auto* self = static_cast<TizenViewElementary*>(data);
-    if (self->view_delegate_) {
-      if (self->container_ == object) {
-        auto* mouse_event =
-            reinterpret_cast<Evas_Event_Mouse_Move*>(event_info);
-        mouse_event->event_flags = Evas_Event_Flags(mouse_event->event_flags |
-                                                    EVAS_EVENT_FLAG_ON_HOLD);
-        if (!self->scroll_hold_) {
-          elm_object_scroll_hold_push(self->container_);
-          self->scroll_hold_ = true;
-        }
+  evas_object_callbacks_[EVAS_CALLBACK_MOUSE_MOVE] =
+      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
+        auto* self = static_cast<TizenViewElementary*>(data);
+        if (self->view_delegate_) {
+          if (self->container_ == object) {
+            auto* mouse_event =
+                reinterpret_cast<Evas_Event_Mouse_Move*>(event_info);
+            mouse_event->event_flags = Evas_Event_Flags(
+                mouse_event->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
+            if (!self->scroll_hold_) {
+              elm_object_scroll_hold_push(self->container_);
+              self->scroll_hold_ = true;
+            }
 
-        TizenGeometry geometry = self->GetGeometry();
-        self->view_delegate_->OnPointerMove(
-            mouse_event->cur.canvas.x - geometry.left,
-            mouse_event->cur.canvas.y - geometry.top, mouse_event->timestamp,
-            reinterpret_cast<intptr_t>(mouse_event->dev));
-      }
-    }
-  };
+            TizenGeometry geometry = self->GetGeometry();
+            self->view_delegate_->OnPointerMove(
+                mouse_event->cur.canvas.x - geometry.left,
+                mouse_event->cur.canvas.y - geometry.top,
+                mouse_event->timestamp, ToFlutterDeviceKind(mouse_event->dev),
+                reinterpret_cast<intptr_t>(mouse_event->dev));
+          }
+        }
+      };
   evas_object_event_callback_add(
       container_, EVAS_CALLBACK_MOUSE_MOVE,
       evas_object_callbacks_[EVAS_CALLBACK_MOUSE_MOVE], this);
@@ -226,6 +238,7 @@ void TizenViewElementary::RegisterEventHandlers() {
             self->view_delegate_->OnScroll(
                 wheel_event->x - geometry.left, wheel_event->y - geometry.top,
                 delta_x, delta_y, wheel_event->timestamp,
+                ToFlutterDeviceKind(wheel_event->dev),
                 reinterpret_cast<intptr_t>(wheel_event->dev));
           }
         }

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 

--- a/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
+++ b/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
@@ -24,18 +24,21 @@ class TizenViewEventHandlerDelegate {
   virtual void OnPointerMove(double x,
                              double y,
                              size_t timestamp,
+                             FlutterPointerDeviceKind device_kind,
                              int32_t device_id) = 0;
 
   virtual void OnPointerDown(double x,
                              double y,
                              FlutterPointerMouseButtons button,
                              size_t timestamp,
+                             FlutterPointerDeviceKind device_kind,
                              int32_t device_id) = 0;
 
   virtual void OnPointerUp(double x,
                            double y,
                            FlutterPointerMouseButtons button,
                            size_t timestamp,
+                           FlutterPointerDeviceKind device_kind,
                            int32_t device_id) = 0;
 
   virtual void OnScroll(double x,
@@ -43,6 +46,7 @@ class TizenViewEventHandlerDelegate {
                         double delta_x,
                         double delta_y,
                         size_t timestamp,
+                        FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
 
   virtual void OnKey(const char* key,

--- a/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
+++ b/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
@@ -24,28 +24,25 @@ class TizenViewEventHandlerDelegate {
   virtual void OnPointerMove(double x,
                              double y,
                              size_t timestamp,
-                             FlutterPointerDeviceKind device_kind,
                              int32_t device_id) = 0;
 
   virtual void OnPointerDown(double x,
                              double y,
+                             FlutterPointerMouseButtons button,
                              size_t timestamp,
-                             FlutterPointerDeviceKind device_kind,
                              int32_t device_id) = 0;
 
   virtual void OnPointerUp(double x,
                            double y,
+                           FlutterPointerMouseButtons button,
                            size_t timestamp,
-                           FlutterPointerDeviceKind device_kind,
                            int32_t device_id) = 0;
 
   virtual void OnScroll(double x,
                         double y,
                         double delta_x,
                         double delta_y,
-                        int scroll_offset_multiplier,
                         size_t timestamp,
-                        FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
 
   virtual void OnKey(const char* key,

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -17,7 +17,16 @@ namespace {
 
 constexpr int kScrollDirectionVertical = 0;
 constexpr int kScrollDirectionHorizontal = 1;
-constexpr int kScrollOffsetMultiplier = 20;
+
+FlutterPointerMouseButtons ToFlutterPointerButton(int32_t button) {
+  if (button == 2) {
+    return kFlutterPointerButtonMouseMiddle;
+  } else if (button == 3) {
+    return kFlutterPointerButtonMouseSecondary;
+  } else {
+    return kFlutterPointerButtonMousePrimary;
+  }
+}
 
 }  // namespace
 
@@ -240,8 +249,9 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
               reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
           if (button_event->window == self->GetWindowId()) {
             self->view_delegate_->OnPointerDown(
-                button_event->x, button_event->y, button_event->timestamp,
-                kFlutterPointerDeviceKindTouch, button_event->multi.device);
+                button_event->x, button_event->y,
+                ToFlutterPointerButton(button_event->buttons),
+                button_event->timestamp, button_event->multi.device);
             return ECORE_CALLBACK_DONE;
           }
         }
@@ -258,8 +268,9 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
               reinterpret_cast<Ecore_Event_Mouse_Button*>(event);
           if (button_event->window == self->GetWindowId()) {
             self->view_delegate_->OnPointerUp(
-                button_event->x, button_event->y, button_event->timestamp,
-                kFlutterPointerDeviceKindTouch, button_event->multi.device);
+                button_event->x, button_event->y,
+                ToFlutterPointerButton(button_event->buttons),
+                button_event->timestamp, button_event->multi.device);
             return ECORE_CALLBACK_DONE;
           }
         }
@@ -274,9 +285,9 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
         if (self->view_delegate_) {
           auto* move_event = reinterpret_cast<Ecore_Event_Mouse_Move*>(event);
           if (move_event->window == self->GetWindowId()) {
-            self->view_delegate_->OnPointerMove(
-                move_event->x, move_event->y, move_event->timestamp,
-                kFlutterPointerDeviceKindTouch, move_event->multi.device);
+            self->view_delegate_->OnPointerMove(move_event->x, move_event->y,
+                                                move_event->timestamp,
+                                                move_event->multi.device);
             return ECORE_CALLBACK_DONE;
           }
         }
@@ -300,10 +311,9 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
               delta_x += wheel_event->z;
             }
 
-            self->view_delegate_->OnScroll(
-                wheel_event->x, wheel_event->y, delta_x, delta_y,
-                kScrollOffsetMultiplier, wheel_event->timestamp,
-                kFlutterPointerDeviceKindTouch, 0);
+            self->view_delegate_->OnScroll(wheel_event->x, wheel_event->y,
+                                           delta_x, delta_y,
+                                           wheel_event->timestamp, 0);
             return ECORE_CALLBACK_DONE;
           }
         }

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -8,6 +8,7 @@
 #include <dlfcn.h>
 #endif
 
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 
@@ -30,9 +31,9 @@ FlutterPointerMouseButtons ToFlutterPointerButton(int32_t button) {
 
 FlutterPointerDeviceKind ToFlutterDeviceKind(const Ecore_Device* dev) {
   Ecore_Device_Class device_class = ecore_device_class_get(dev);
-  if (device_class == ECORE_INPUT_DEVICE_TYPE_MOUSE) {
+  if (device_class == ECORE_DEVICE_CLASS_MOUSE) {
     return kFlutterPointerDeviceKindMouse;
-  } else if (device_class == ECORE_INPUT_DEVICE_TYPE_PEN) {
+  } else if (device_class == ECORE_DEVICE_CLASS_PEN) {
     return kFlutterPointerDeviceKindStylus;
   } else {
     return kFlutterPointerDeviceKindTouch;

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -8,6 +8,7 @@
 #include <eom.h>
 #include <ui/efl_util.h>
 
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h"
 


### PR DESCRIPTION
Contributes to https://github.com/flutter-tizen/flutter-tizen/issues/490.

- Specify `FlutterPointerEvent.device_kind` according to the actual device type.
- Handle multi device states correctly.
- Handle mouse hover events and right and middle click events correctly.
- Fix `Evas_Event_Mouse_Down.button` being incorrectly used as a device ID and use `mouse_event->dev` instead.
- Update `kScrollOffsetMultiplier` with the value used by Chromium/Linux GTK.

The code added to `flutter_tizen_view.cc` is mostly based on the Windows implementation (`flutter_windows_view.cc`).

To test right and middle clicks, you can use the `GestureDetector` widget (`onSecondaryTapDown`/`onTertiaryTapDown`).