### PR TITLE
[TizenAppControl] Add SetAutoRestart method

### DIFF
--- a/flutter/shell/platform/tizen/channels/app_control.cc
+++ b/flutter/shell/platform/tizen/channels/app_control.cc
@@ -369,4 +369,12 @@ AppControlResult AppControl::Reply(AppControl* reply,
                                              result_e);
 }
 
+AppControlResult AppControl::SetAutoRestart(bool enabled) {
+  if (enabled) {
+    return app_control_set_auto_restart(handle_);
+  }
+
+  return app_control_unset_auto_restart();
+}
+
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/channels/app_control.h
+++ b/flutter/shell/platform/tizen/channels/app_control.h
@@ -95,6 +95,7 @@ class AppControl {
   AppControlResult SendTerminateRequest();
 
   AppControlResult Reply(AppControl* reply, const std::string& result);
+  AppControlResult SetAutoRestart(bool enabled);
 
  private:
   AppControlResult GetString(std::string& string,

--- a/flutter/shell/platform/tizen/channels/app_control_channel.cc
+++ b/flutter/shell/platform/tizen/channels/app_control_channel.cc
@@ -4,6 +4,10 @@
 
 #include "app_control_channel.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/event_stream_handler_functions.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
@@ -100,6 +104,8 @@ void AppControlChannel::HandleMethodCall(
     SendTerminateRequest(app_control, std::move(result));
   } else if (method_name == "setAppControlData") {
     SetAppControlData(app_control, arguments, std::move(result));
+  } else if (method_name == "setAutoRestart") {
+    SetAutoRestart(app_control, arguments, std::move(result));
   } else {
     result->NotImplemented();
   }
@@ -234,6 +240,18 @@ void AppControlChannel::SendAppControlEvent(AppControl* app_control) {
   EncodableValue map = app_control->SerializeToMap();
   if (!map.IsNull()) {
     event_sink_->Success(map);
+  }
+}
+
+void AppControlChannel::SetAutoRestart(
+    AppControl* app_control, const EncodableMap* arguments,
+    std::unique_ptr<MethodResult<EncodableValue>> result) {
+  EncodableValueHolder<bool> enabled(arguments, "enabled");
+  AppControlResult ret = app_control->SetAutoRestart(*enabled);
+  if (ret) {
+    result->Success();
+  } else {
+    result->Error(ret.code(), ret.message());
   }
 }
 

--- a/flutter/shell/platform/tizen/channels/app_control_channel.h
+++ b/flutter/shell/platform/tizen/channels/app_control_channel.h
@@ -44,6 +44,9 @@ class AppControlChannel {
 
   void SendAppControlEvent(AppControl* app_control);
 
+  void SetAutoRestart(AppControl* app_control, const EncodableMap* arguments,
+                      std::unique_ptr<MethodResult<EncodableValue>> result);
+
   std::unique_ptr<MethodChannel<EncodableValue>> method_channel_;
   std::unique_ptr<EventChannel<EncodableValue>> event_channel_;
   std::unique_ptr<EventSink<EncodableValue>> event_sink_;

--- a/tools/generate_sysroot.py
+++ b/tools/generate_sysroot.py
@@ -137,10 +137,10 @@ def generate_sysroot(sysroot: Path, api_version: float, arch: str, quiet=False):
   else:
     sys.exit('Unknown arch: ' + arch)
 
-  base_repo = 'http://download.tizen.org/snapshots/tizen/{}-base/latest/repos/standard/packages'.format(
-    api_version)
-  unified_repo = 'http://download.tizen.org/snapshots/tizen/{}-unified/latest/repos/standard/packages'.format(
-    api_version)
+  base_repo = 'http://download.tizen.org/snapshots/TIZEN/Tizen-{}/Tizen-{}-Base/latest/repos/standard/packages'.format(
+    api_version, api_version)
+  unified_repo = 'http://download.tizen.org/snapshots/TIZEN/Tizen-{}/Tizen-{}-Unified/latest/repos/standard/packages'.format(
+    api_version, api_version)
 
   # Retrieve html documents.
   documents = {}


### PR DESCRIPTION
The app_control_set_auto_restart() is supported since tizen 7.0.
The application can set the auto restart option at runtime using the function.
To use the function, the application has to be signed using the platform level certificate.