### PR TITLE
Fix memory leak issue

### DIFF
--- a/flutter/shell/platform/tizen/external_texture_surface_egl.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_egl.cc
@@ -38,7 +38,6 @@ ExternalTextureSurfaceEGL::~ExternalTextureSurfaceEGL() {
   if (state_->gl_texture != 0) {
     glDeleteTextures(1, static_cast<GLuint*>(&state_->gl_texture));
   }
-  state_.release();
 }
 
 bool ExternalTextureSurfaceEGL::PopulateTexture(

--- a/flutter/shell/platform/tizen/external_texture_surface_evas_gl.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_evas_gl.cc
@@ -26,7 +26,6 @@ ExternalTextureSurfaceEvasGL::~ExternalTextureSurfaceEvasGL() {
   if (state_->gl_texture != 0) {
     glDeleteTextures(1, static_cast<GLuint*>(&state_->gl_texture));
   }
-  state_.release();
 }
 
 bool ExternalTextureSurfaceEvasGL::PopulateTexture(


### PR DESCRIPTION
std::unique_ptr::release, just releases the ownership of the managed object, the caller is responsible for deleting the object.
