### PR TITLE
Update libcxx and other dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,15 +4,15 @@
 
 deps = {
   'src/third_party/rapidjson': 'https://fuchsia.googlesource.com/third_party/rapidjson@ef3564c5c8824989393b87df25355baf35ff544b',
-  'src/third_party/libcxx': 'https://llvm.googlesource.com/llvm-project/libcxx@54c3dc7343f40254bdb069699202e6d65eda66a2',
-  'src/third_party/libcxxabi': 'https://llvm.googlesource.com/llvm-project/libcxxabi@65a68da0f1b102574db316d326a53735b03a4574',
+  'src/third_party/libcxx': 'https://llvm.googlesource.com/llvm-project/libcxx@44079a4cc04cdeffb9cfe8067bfb3c276fb2bab0',
+  'src/third_party/libcxxabi': 'https://llvm.googlesource.com/llvm-project/libcxxabi@2ce528fb5e0f92e57c97ec3ff53b75359d33af12',
   'src/third_party/googletest': 'https://github.com/google/googletest@054a986a8513149e8374fc669a5fe40117ca6b41',
-  'src/third_party/dart': 'https://dart.googlesource.com/sdk.git@63c2197b976931c6472d9dc9574f98ff2ae9408c',
+  'src/third_party/dart': 'https://dart.googlesource.com/sdk.git@1618a775995ef6f862b9f05be61a6a8fc23f2e4d',
   'src/third_party/clang': {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/linux-amd64',
-        'version': 'ugk-KfeqO9fhSfhBFRG4Z-56Kr2AQVSEbku9AEUdotYC'
+        'version': 'git_revision:20d06c833d833ef6b2d0f519cc4a7998d49a2803'
       }
     ],
     'dep_type': 'cipd',
@@ -30,7 +30,7 @@ deps = {
     'packages': [
       {
         'package': 'infra/3pp/tools/ninja/${{platform}}',
-        'version': 'version:2@1.8.2.chromium.3',
+        'version': 'version:2@1.11.1.chromium.4',
       }
     ],
     'dep_type': 'cipd',

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The Flutter embedder for Tizen.
 
 `cd` into the generated `src` directory and run the following commands.
 
-Note: The toolchain path (`/usr/lib/llvm-12`) can be replaced as you want. For example, you can use `~/tizen-studio/tools/llvm-10` if you have [Tizen Studio](https://developer.tizen.org/development/tizen-studio/download) and the `NativeToolchain-Gcc-9.2` package installed.
-
 - **For arm**
 
   ```sh

--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -112,6 +112,10 @@ config("cxx_version_11") {
   cflags_cc = [ "-std=c++11" ]
 }
 
+config("cxx_version_20") {
+  cflags_cc = [ "-std=c++20" ]
+}
+
 config("no_system_cxx") {
   cflags_cc = [ "-nostdinc++" ]
   ldflags = [ "-nostdlib++" ]

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -41,7 +41,11 @@ _default_configs = [
 if (use_system_cxx) {
   _default_configs += [ "//build/config:system_cxx" ]
 } else {
-  _default_configs += [ "//build/config:no_system_cxx" ]
+  _default_configs += [
+    "//build/config:no_system_cxx",
+    "//third_party/libcxxabi:libcxxabi_config",
+    "//third_party/libcxx:libcxx_config",
+  ]
 }
 
 if (is_unopt) {

--- a/build/secondary/third_party/libcxx/BUILD.gn
+++ b/build/secondary/third_party/libcxx/BUILD.gn
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+config("libcxx_config") {
+  defines = [ "_LIBCPP_DISABLE_AVAILABILITY=1" ]
+  include_dirs = [ "//build/secondary/third_party/libcxx/config" ]
+}
+
+config("src_include") {
+  include_dirs = [ "src" ]
+}
+
 source_set("libcxx") {
   sources = [
     "src/algorithm.cpp",
@@ -21,6 +30,7 @@ source_set("libcxx") {
     "src/future.cpp",
     "src/hash.cpp",
     "src/ios.cpp",
+    "src/ios.instantiations.cpp",
     "src/iostream.cpp",
     "src/locale.cpp",
     "src/memory.cpp",
@@ -30,6 +40,9 @@ source_set("libcxx") {
     "src/optional.cpp",
     "src/random.cpp",
     "src/regex.cpp",
+    "src/ryu/d2fixed.cpp",
+    "src/ryu/d2s.cpp",
+    "src/ryu/f2s.cpp",
     "src/shared_mutex.cpp",
     "src/stdexcept.cpp",
     "src/string.cpp",
@@ -45,7 +58,10 @@ source_set("libcxx") {
 
   deps = [ "//third_party/libcxxabi" ]
 
-  public_configs = [ "//third_party/libcxxabi:libcxxabi_config" ]
+  public_configs = [
+    ":libcxx_config",
+    "//third_party/libcxxabi:libcxxabi_config",
+  ]
 
   defines = [
     "_LIBCPP_NO_EXCEPTIONS",
@@ -53,6 +69,12 @@ source_set("libcxx") {
     "_LIBCPP_BUILDING_LIBRARY",
     "LIBCXX_BUILDING_LIBCXXABI",
   ]
+
+  # libcxx requires C++20.
+  configs -= [ "//build/config:cxx_version_default" ]
+  configs += [ "//build/config:cxx_version_20" ]
+
+  configs += [ ":src_include" ]
 
   # shared_mutex.cpp and debug.cpp are purposefully in violation.
   cflags_cc = [ "-Wno-thread-safety-analysis" ]

--- a/build/secondary/third_party/libcxx/config/__config_site
+++ b/build/secondary/third_party/libcxx/config/__config_site
@@ -1,0 +1,39 @@
+#ifndef _LIBCPP_CONFIG_SITE
+#define _LIBCPP_CONFIG_SITE
+
+/* #undef _LIBCPP_ABI_VERSION */
+/* #undef _LIBCPP_ABI_UNSTABLE */
+/* #undef _LIBCPP_ABI_FORCE_ITANIUM */
+/* #undef _LIBCPP_ABI_FORCE_MICROSOFT */
+/* #undef _LIBCPP_HIDE_FROM_ABI_PER_TU_BY_DEFAULT */
+/* #undef _LIBCPP_HAS_NO_GLOBAL_FILESYSTEM_NAMESPACE */
+/* #undef _LIBCPP_HAS_NO_STDIN */
+/* #undef _LIBCPP_HAS_NO_STDOUT */
+/* #undef _LIBCPP_HAS_NO_THREADS */
+/* #undef _LIBCPP_HAS_NO_MONOTONIC_CLOCK */
+/* #undef _LIBCPP_HAS_NO_THREAD_UNSAFE_C_FUNCTIONS */
+/* #undef _LIBCPP_HAS_MUSL_LIBC */
+/* #undef _LIBCPP_HAS_THREAD_API_PTHREAD */
+/* #undef _LIBCPP_HAS_THREAD_API_EXTERNAL */
+/* #undef _LIBCPP_HAS_THREAD_API_WIN32 */
+/* #undef _LIBCPP_HAS_THREAD_LIBRARY_EXTERNAL */
+/* #undef _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS */
+#define _LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS
+/* #undef _LIBCPP_NO_VCRUNTIME */
+/* #undef _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION */
+/* #undef _LIBCPP_ABI_NAMESPACE */
+/* #undef _LIBCPP_HAS_NO_FILESYSTEM_LIBRARY */
+/* #undef _LIBCPP_HAS_PARALLEL_ALGORITHMS */
+/* #undef _LIBCPP_HAS_NO_RANDOM_DEVICE */
+/* #undef _LIBCPP_HAS_NO_LOCALIZATION */
+
+#define _LIBCPP_REMOVE_TRANSITIVE_INCLUDES
+
+// This is a workaround for BoringSSL, which is compiled in C11 mode
+// and includes stdatomic.h.  Defining this macro will cause stdatomic.h
+// to redirect to the next version of that header in the include path.
+#if !defined(__cplusplus) && defined(__clang__)
+#define _LIBCPP_COMPILER_CLANG_BASED
+#endif
+
+#endif // _LIBCPP_CONFIG_SITE

--- a/build/secondary/third_party/libcxxabi/BUILD.gn
+++ b/build/secondary/third_party/libcxxabi/BUILD.gn
@@ -16,20 +16,18 @@ source_set("libcxxabi") {
   public_configs = [ ":libcxxabi_config" ]
 
   defines = [
-    "_LIBCXXABI_NO_EXCEPTIONS",
+    "_LIBCPP_BUILDING_LIBRARY",
     "_LIBCXXABI_BUILDING_LIBRARY",
     "LIBCXXABI_SILENT_TERMINATE",
     "_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
   ]
 
-  sources = [ "src/cxa_noexception.cpp" ]
-
-  # Compile libcxx ABI using C++11. This replicates the rule in the
-  # CMakeLists on the "cxx_abiobjects" target.
   configs -= [ "//build/config:cxx_version_default" ]
-  configs += [ "//build/config:cxx_version_11" ]
+  configs += [ "//build/config:cxx_version_20" ]
 
-  sources += [
+  configs += [ "//third_party/libcxx:src_include" ]
+
+  sources = [
     "src/abort_message.cpp",
     "src/cxa_aux_runtime.cpp",
     "src/cxa_default_handlers.cpp",
@@ -37,7 +35,7 @@ source_set("libcxxabi") {
     "src/cxa_exception_storage.cpp",
     "src/cxa_guard.cpp",
     "src/cxa_handlers.cpp",
-    "src/cxa_unexpected.cpp",
+    "src/cxa_noexception.cpp",
     "src/cxa_vector.cpp",
     "src/cxa_virtual.cpp",
     "src/fallback_malloc.cpp",

--- a/flutter/shell/platform/tizen/channels/key_event_channel.cc
+++ b/flutter/shell/platform/tizen/channels/key_event_channel.cc
@@ -36,7 +36,10 @@ constexpr char kLinuxKeyMap[] = "linux";
 constexpr size_t kMaxPendingEvents = 1000;
 
 uint32_t Utf8ToUtf32CodePoint(const char* utf8) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+#pragma clang diagnostic pop
   for (wchar_t wchar : converter.from_bytes(utf8)) {
     return wchar;
   }

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -371,10 +371,9 @@ void FlutterTizenEngine::SetupLocales() {
   // Convert the locale list to the locale pointer list that must be provided.
   std::vector<const FlutterLocale*> flutter_locale_list;
   flutter_locale_list.reserve(flutter_locales.size());
-  std::transform(
-      flutter_locales.begin(), flutter_locales.end(),
-      std::back_inserter(flutter_locale_list),
-      [](const auto& arg) -> const auto* { return &arg; });
+  std::transform(flutter_locales.begin(), flutter_locales.end(),
+                 std::back_inserter(flutter_locale_list),
+                 [](const auto& arg) -> const auto* { return &arg; });
 
   embedder_api_.UpdateLocales(engine_, flutter_locale_list.data(),
                               flutter_locale_list.size());

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -160,9 +160,9 @@ void TizenWindowEcoreWl2::EnableCursor() {
   }
 
   // These functions are defined in vd-win-util's cursor_module.h.
-  int (*CursorModule_Initialize)(wl_display * display, wl_registry * registry,
-                                 wl_seat * seat, unsigned int id);
-  int (*Cursor_Set_Config)(wl_surface * surface, uint32_t config_type,
+  int (*CursorModule_Initialize)(wl_display* display, wl_registry* registry,
+                                 wl_seat* seat, unsigned int id);
+  int (*Cursor_Set_Config)(wl_surface* surface, uint32_t config_type,
                            void* data);
   void (*CursorModule_Finalize)(void);
   *(void**)(&CursorModule_Initialize) =

--- a/flutter/third_party/accessibility/ax/ax_event_generator.h
+++ b/flutter/third_party/accessibility/ax/ax_event_generator.h
@@ -125,9 +125,14 @@ class AX_EXPORT AXEventGenerator : public AXTreeObserver {
     const EventParams& event_params;
   };
 
-  class AX_EXPORT Iterator
-      : public std::iterator<std::input_iterator_tag, TargetedEvent> {
+  class AX_EXPORT Iterator {
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = TargetedEvent;
+    using difference_type = std::ptrdiff_t;
+    using pointer = TargetedEvent*;
+    using reference = TargetedEvent&;
+
     Iterator(
         const std::map<AXNode*, std::set<EventParams>>& map,
         const std::map<AXNode*, std::set<EventParams>>::const_iterator& head);


### PR DESCRIPTION
- Align libcxx, libcxxabi, dart-sdk, clang, and ninja versions with Flutter 3.10.
- Compile libcxx using C++20. See https://github.com/flutter/buildroot/commit/633907dfb90f6e8d97ad122aa66cf2d4207cda9b for details.
- Resolve deprecation warnings.
- Format the source code with the updated clang-format (clang-format-16).
