### PR TITLE
Fix coredump issue during exit app

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -216,6 +216,7 @@ bool FlutterTizenEngine::RunEngine() {
     vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
     args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
       auto* engine = static_cast<FlutterTizenEngine*>(user_data);
+      std::lock_guard<std::mutex> lock(engine->vsync_mutex_);
       if (engine->vsync_waiter_) {
         engine->vsync_waiter_->AsyncWaitForVsync(baton);
       }
@@ -268,6 +269,7 @@ bool FlutterTizenEngine::StopEngine() {
       callback(registrar);
     }
 #ifndef WEARABLE_PROFILE
+    std::lock_guard<std::mutex> lock(vsync_mutex_);
     if (vsync_waiter_) {
       vsync_waiter_.reset();
     }

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -269,9 +269,11 @@ bool FlutterTizenEngine::StopEngine() {
       callback(registrar);
     }
 #ifndef WEARABLE_PROFILE
-    std::lock_guard<std::mutex> lock(vsync_mutex_);
-    if (vsync_waiter_) {
-      vsync_waiter_.reset();
+    {
+      std::lock_guard<std::mutex> lock(vsync_mutex_);
+      if (vsync_waiter_) {
+        vsync_waiter_.reset();
+      }
     }
 #endif
     FlutterEngineResult result = embedder_api_.Shutdown(engine_);

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -216,7 +216,9 @@ bool FlutterTizenEngine::RunEngine() {
     vsync_waiter_ = std::make_unique<TizenVsyncWaiter>(this);
     args.vsync_callback = [](void* user_data, intptr_t baton) -> void {
       auto* engine = static_cast<FlutterTizenEngine*>(user_data);
-      engine->vsync_waiter_->AsyncWaitForVsync(baton);
+      if (engine->vsync_waiter_) {
+        engine->vsync_waiter_->AsyncWaitForVsync(baton);
+      }
     };
   }
 #endif

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -273,6 +273,7 @@ class FlutterTizenEngine {
 
 #ifndef WEARABLE_PROFILE
   std::mutex vsync_mutex_;
+
   // The vsync waiter for the embedder.
   std::unique_ptr<TizenVsyncWaiter> vsync_waiter_;
 #endif

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -272,6 +272,7 @@ class FlutterTizenEngine {
   std::unique_ptr<TizenRenderer> renderer_;
 
 #ifndef WEARABLE_PROFILE
+  std::mutex vsync_mutex_;
   // The vsync waiter for the embedder.
   std::unique_ptr<TizenVsyncWaiter> vsync_waiter_;
 #endif


### PR DESCRIPTION
Need check whether vsync_waiter_ is a null pointer, because during stop engine process, may receive a request for vsync.