### PR TITLE
Add the input device channel

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -83,6 +83,7 @@ template("embedder") {
       "channels/app_control.cc",
       "channels/app_control_channel.cc",
       "channels/feedback_manager.cc",
+      "channels/input_device_channel.cc",
       "channels/key_event_channel.cc",
       "channels/key_mapping.cc",
       "channels/lifecycle_channel.cc",

--- a/flutter/shell/platform/tizen/channels/input_device_channel.cc
+++ b/flutter/shell/platform/tizen/channels/input_device_channel.cc
@@ -10,7 +10,7 @@ namespace flutter {
 
 namespace {
 
-constexpr char kChannelName[] = "tizen/internal/input_device";
+constexpr char kChannelName[] = "tizen/internal/inputdevice";
 
 }  // namespace
 

--- a/flutter/shell/platform/tizen/channels/input_device_channel.cc
+++ b/flutter/shell/platform/tizen/channels/input_device_channel.cc
@@ -1,0 +1,45 @@
+// Copyright 2023 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "input_device_channel.h"
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
+
+namespace flutter {
+
+namespace {
+
+constexpr char kChannelName[] = "tizen/internal/input_device";
+
+}  // namespace
+
+InputDeviceChannel::InputDeviceChannel(BinaryMessenger* messenger)
+    : channel_(std::make_unique<MethodChannel<EncodableValue>>(
+          messenger,
+          kChannelName,
+          &StandardMethodCodec::GetInstance())) {
+  channel_->SetMethodCallHandler(
+      [this](const MethodCall<EncodableValue>& call,
+             std::unique_ptr<MethodResult<EncodableValue>> result) {
+        this->HandleMethodCall(call, std::move(result));
+      });
+}
+
+InputDeviceChannel::~InputDeviceChannel() {}
+
+void InputDeviceChannel::HandleMethodCall(
+    const MethodCall<EncodableValue>& method_call,
+    std::unique_ptr<MethodResult<EncodableValue>> result) {
+  const std::string& method_name = method_call.method_name();
+
+  if (method_name == "getLastUsedKeyboard") {
+    EncodableMap map;
+    map[EncodableValue("name")] = EncodableValue(last_keyboard_name_);
+    result->Success(EncodableValue(map));
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace flutter

--- a/flutter/shell/platform/tizen/channels/input_device_channel.h
+++ b/flutter/shell/platform/tizen/channels/input_device_channel.h
@@ -1,0 +1,38 @@
+// Copyright 2023 Samsung Electronics Co., Ltd. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef EMBEDDER_INPUT_DEVICE_CHANNEL_H_
+#define EMBEDDER_INPUT_DEVICE_CHANNEL_H_
+
+#include <memory>
+#include <string>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+
+namespace flutter {
+
+class InputDeviceChannel {
+ public:
+  explicit InputDeviceChannel(BinaryMessenger* messenger);
+  virtual ~InputDeviceChannel();
+
+  void SetLastKeyboardInfo(const std::string& name) {
+    last_keyboard_name_ = name;
+  }
+
+ private:
+  void HandleMethodCall(const MethodCall<EncodableValue>& method_call,
+                        std::unique_ptr<MethodResult<EncodableValue>> result);
+
+  std::unique_ptr<MethodChannel<EncodableValue>> channel_;
+
+  // The name of the last keyboard device used.
+  std::string last_keyboard_name_;
+};
+
+}  // namespace flutter
+
+#endif  // EMBEDDER_INPUT_DEVICE_CHANNEL_H_

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -291,7 +291,7 @@ void FlutterDesktopViewOnKeyEvent(FlutterDesktopViewRef view,
   }
 #else
   ViewFromHandle(view)->OnKey(key, string, nullptr, modifiers, scan_code,
-                              is_down);
+                              device_name, is_down);
 #endif
 }
 

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -332,7 +332,7 @@ void FlutterTizenView::OnKey(const char* key,
     return;
   }
 
-  if (input_device_channel_) {
+  if (input_device_channel_ && is_down) {
     input_device_channel_->SetLastKeyboardInfo(
         device_name ? std::string(device_name) : std::string());
   }

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -5,6 +5,7 @@
 
 #include "flutter_tizen_view.h"
 
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/logger.h"
 #include "flutter/shell/platform/tizen/tizen_view.h"
 #ifdef NUI_SUPPORT
@@ -26,6 +27,8 @@ constexpr double kProfileFactor = 2.0;
 #else
 constexpr double kProfileFactor = 1.0;
 #endif
+
+constexpr char kInputDeviceChannelName[] = "tizen/internal/input_device";
 
 constexpr char kSysMenuKey[] = "XF86SysMenu";
 constexpr char kBackKey[] = "XF86Back";
@@ -109,6 +112,21 @@ void FlutterTizenView::SetEngine(std::unique_ptr<FlutterTizenEngine> engine) {
   text_input_channel_ = std::make_unique<TextInputChannel>(
       internal_plugin_registrar_->messenger(),
       tizen_view_->input_method_context());
+
+  input_device_channel_ = std::make_unique<MethodChannel<EncodableValue>>(
+      messenger, kInputDeviceChannelName, &StandardMethodCodec::GetInstance());
+  input_device_channel_->SetMethodCallHandler(
+      [this](const MethodCall<EncodableValue>& call,
+             std::unique_ptr<MethodResult<EncodableValue>> result) {
+        const std::string& method_name = call.method_name();
+        if (method_name == "getLastUsedKeyboard") {
+          EncodableMap map;
+          map[EncodableValue("name")] = EncodableValue(last_keyboard_name_);
+          result->Success(EncodableValue(map));
+        } else {
+          result->NotImplemented();
+        }
+      });
 }
 
 void FlutterTizenView::CreateRenderSurface(
@@ -318,6 +336,7 @@ void FlutterTizenView::OnKey(const char* key,
                              const char* compose,
                              uint32_t modifiers,
                              uint32_t scan_code,
+                             const char* device_name,
                              bool is_down) {
   if (is_down) {
     FT_LOG(Info) << "Key symbol: " << key << ", code: 0x" << std::setw(8)
@@ -328,6 +347,8 @@ void FlutterTizenView::OnKey(const char* key,
   if (strcmp(key, kSysMenuKey) == 0) {
     return;
   }
+
+  last_keyboard_name_ = device_name ? std::string(device_name) : std::string();
 
   if (text_input_channel_) {
     if (text_input_channel_->SendKey(key, string, compose, modifiers, scan_code,

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -6,9 +6,12 @@
 #ifndef EMBEDDER_FLUTTER_TIZEN_VIEW_H_
 #define EMBEDDER_FLUTTER_TIZEN_VIEW_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/tizen/channels/mouse_cursor_channel.h"
@@ -95,6 +98,7 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
              const char* compose,
              uint32_t modifiers,
              uint32_t scan_code,
+             const char* device_name,
              bool is_down) override;
 
   void OnComposeBegin() override;
@@ -182,7 +186,7 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // A plugin that implements the Flutter platform channel.
   std::unique_ptr<PlatformChannel> platform_channel_;
 
-  // A plugin that implements the Flutter platform_views channel.
+  // A plugin that implements the Flutter platform view channel.
   std::unique_ptr<PlatformViewChannel> platform_view_channel_;
 
   // A plugin that implements the Flutter cursor channel.
@@ -197,6 +201,12 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // The current view transformation.
   FlutterTransformation flutter_transformation_ = {1.0, 0.0, 0.0, 0.0, 1.0,
                                                    0.0, 0.0, 0.0, 1.0};
+
+  // A channel for reporting input device information.
+  std::unique_ptr<MethodChannel<EncodableValue>> input_device_channel_;
+
+  // The name of the last keyboard device used.
+  std::string last_keyboard_name_;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -10,10 +10,9 @@
 #include <memory>
 #include <string>
 
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/tizen/channels/input_device_channel.h"
 #include "flutter/shell/platform/tizen/channels/mouse_cursor_channel.h"
 #include "flutter/shell/platform/tizen/channels/platform_channel.h"
 #include "flutter/shell/platform/tizen/channels/text_input_channel.h"
@@ -195,18 +194,15 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // A plugin that implements the Flutter textinput channel.
   std::unique_ptr<TextInputChannel> text_input_channel_;
 
+  // A plugin to report input device information.
+  std::unique_ptr<InputDeviceChannel> input_device_channel_;
+
   // The current view rotation degree.
   int32_t rotation_degree_ = 0;
 
   // The current view transformation.
   FlutterTransformation flutter_transformation_ = {1.0, 0.0, 0.0, 0.0, 1.0,
                                                    0.0, 0.0, 0.0, 1.0};
-
-  // A channel for reporting input device information.
-  std::unique_ptr<MethodChannel<EncodableValue>> input_device_channel_;
-
-  // The name of the last keyboard device used.
-  std::string last_keyboard_name_;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -266,7 +266,7 @@ void TizenViewElementary::RegisterEventHandlers() {
           self->view_delegate_->OnKey(
               key_event->key, key_event->string, key_event->compose,
               EvasModifierToEcoreEventModifiers(key_event->modifiers),
-              key_event->keycode, true);
+              key_event->keycode, evas_device_name_get(key_event->dev), true);
         }
       }
     }
@@ -275,28 +275,29 @@ void TizenViewElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
-      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = static_cast<TizenViewElementary*>(data);
-        if (self->view_delegate_) {
-          if (self->container_ == object && self->focused_) {
-            auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-            bool handled = false;
-            key_event->event_flags = Evas_Event_Flags(key_event->event_flags |
-                                                      EVAS_EVENT_FLAG_ON_HOLD);
-            if (self->input_method_context_->IsInputPanelShown()) {
-              handled =
-                  self->input_method_context_->HandleEvasEventKeyUp(key_event);
-            }
-            if (!handled) {
-              self->view_delegate_->OnKey(
-                  key_event->key, key_event->string, key_event->compose,
-                  EvasModifierToEcoreEventModifiers(key_event->modifiers),
-                  key_event->keycode, false);
-            }
-          }
+  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] = [](void* data, Evas* evas,
+                                                    Evas_Object* object,
+                                                    void* event_info) {
+    auto* self = static_cast<TizenViewElementary*>(data);
+    if (self->view_delegate_) {
+      if (self->container_ == object && self->focused_) {
+        auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
+        bool handled = false;
+        key_event->event_flags =
+            Evas_Event_Flags(key_event->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
+        if (self->input_method_context_->IsInputPanelShown()) {
+          handled =
+              self->input_method_context_->HandleEvasEventKeyUp(key_event);
         }
-      };
+        if (!handled) {
+          self->view_delegate_->OnKey(
+              key_event->key, key_event->string, key_event->compose,
+              EvasModifierToEcoreEventModifiers(key_event->modifiers),
+              key_event->keycode, evas_device_name_get(key_event->dev), false);
+        }
+      }
+    }
+  };
   evas_object_event_callback_add(container_, EVAS_CALLBACK_KEY_UP,
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP],
                                  this);

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -275,29 +275,28 @@ void TizenViewElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] = [](void* data, Evas* evas,
-                                                    Evas_Object* object,
-                                                    void* event_info) {
-    auto* self = static_cast<TizenViewElementary*>(data);
-    if (self->view_delegate_) {
-      if (self->container_ == object && self->focused_) {
-        auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-        bool handled = false;
-        key_event->event_flags =
-            Evas_Event_Flags(key_event->event_flags | EVAS_EVENT_FLAG_ON_HOLD);
-        if (self->input_method_context_->IsInputPanelShown()) {
-          handled =
-              self->input_method_context_->HandleEvasEventKeyUp(key_event);
+  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
+      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
+        auto* self = static_cast<TizenViewElementary*>(data);
+        if (self->view_delegate_) {
+          if (self->container_ == object && self->focused_) {
+            auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
+            bool handled = false;
+            key_event->event_flags = Evas_Event_Flags(key_event->event_flags |
+                                                      EVAS_EVENT_FLAG_ON_HOLD);
+            if (self->input_method_context_->IsInputPanelShown()) {
+              handled =
+                  self->input_method_context_->HandleEvasEventKeyUp(key_event);
+            }
+            if (!handled) {
+              self->view_delegate_->OnKey(
+                  key_event->key, key_event->string, key_event->compose,
+                  EvasModifierToEcoreEventModifiers(key_event->modifiers),
+                  key_event->keycode, nullptr, false);
+            }
+          }
         }
-        if (!handled) {
-          self->view_delegate_->OnKey(
-              key_event->key, key_event->string, key_event->compose,
-              EvasModifierToEcoreEventModifiers(key_event->modifiers),
-              key_event->keycode, evas_device_name_get(key_event->dev), false);
-        }
-      }
-    }
-  };
+      };
   evas_object_event_callback_add(container_, EVAS_CALLBACK_KEY_UP,
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP],
                                  this);

--- a/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
+++ b/flutter/shell/platform/tizen/tizen_view_event_handler_delegate.h
@@ -54,6 +54,7 @@ class TizenViewEventHandlerDelegate {
                      const char* compose,
                      uint32_t modifiers,
                      uint32_t scan_code,
+                     const char* device_name,
                      bool is_down) = 0;
 
   virtual void OnComposeBegin() = 0;

--- a/flutter/shell/platform/tizen/tizen_view_nui.cc
+++ b/flutter/shell/platform/tizen/tizen_view_nui.cc
@@ -93,7 +93,8 @@ void TizenViewNui::OnKey(const char* device_name,
   }
 
   if (!handled) {
-    view_delegate_->OnKey(key, string, compose, modifiers, scan_code, is_down);
+    view_delegate_->OnKey(key, string, compose, modifiers, scan_code,
+                          device_name, is_down);
   }
 }
 

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -357,7 +357,8 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
             if (!handled) {
               self->view_delegate_->OnKey(
                   key_event->key, key_event->string, key_event->compose,
-                  key_event->modifiers, key_event->keycode, true);
+                  key_event->modifiers, key_event->keycode,
+                  ecore_device_name_get(key_event->dev), true);
             }
             return ECORE_CALLBACK_DONE;
           }
@@ -381,7 +382,8 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
             if (!handled) {
               self->view_delegate_->OnKey(
                   key_event->key, key_event->string, key_event->compose,
-                  key_event->modifiers, key_event->keycode, false);
+                  key_event->modifiers, key_event->keycode,
+                  ecore_device_name_get(key_event->dev), false);
             }
             return ECORE_CALLBACK_DONE;
           }

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -382,8 +382,7 @@ void TizenWindowEcoreWl2::RegisterEventHandlers() {
             if (!handled) {
               self->view_delegate_->OnKey(
                   key_event->key, key_event->string, key_event->compose,
-                  key_event->modifiers, key_event->keycode,
-                  ecore_device_name_get(key_event->dev), false);
+                  key_event->modifiers, key_event->keycode, nullptr, false);
             }
             return ECORE_CALLBACK_DONE;
           }

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -309,7 +309,7 @@ void TizenWindowElementary::RegisterEventHandlers() {
           self->view_delegate_->OnKey(
               key_event->key, key_event->string, key_event->compose,
               EvasModifierToEcoreEventModifiers(key_event->modifiers),
-              key_event->keycode, true);
+              key_event->keycode, evas_device_name_get(key_event->dev), true);
         }
       }
     }
@@ -318,26 +318,27 @@ void TizenWindowElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
-      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
-        auto* self = static_cast<TizenWindowElementary*>(data);
-        if (self->view_delegate_) {
-          if (self->elm_win_ == object) {
-            auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-            bool handled = false;
-            if (self->input_method_context_->IsInputPanelShown()) {
-              handled =
-                  self->input_method_context_->HandleEvasEventKeyUp(key_event);
-            }
-            if (!handled) {
-              self->view_delegate_->OnKey(
-                  key_event->key, key_event->string, key_event->compose,
-                  EvasModifierToEcoreEventModifiers(key_event->modifiers),
-                  key_event->keycode, false);
-            }
-          }
+  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] = [](void* data, Evas* evas,
+                                                    Evas_Object* object,
+                                                    void* event_info) {
+    auto* self = static_cast<TizenWindowElementary*>(data);
+    if (self->view_delegate_) {
+      if (self->elm_win_ == object) {
+        auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
+        bool handled = false;
+        if (self->input_method_context_->IsInputPanelShown()) {
+          handled =
+              self->input_method_context_->HandleEvasEventKeyUp(key_event);
         }
-      };
+        if (!handled) {
+          self->view_delegate_->OnKey(
+              key_event->key, key_event->string, key_event->compose,
+              EvasModifierToEcoreEventModifiers(key_event->modifiers),
+              key_event->keycode, evas_device_name_get(key_event->dev), false);
+        }
+      }
+    }
+  };
   evas_object_event_callback_add(elm_win_, EVAS_CALLBACK_KEY_UP,
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP],
                                  this);

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -318,27 +318,26 @@ void TizenWindowElementary::RegisterEventHandlers() {
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_DOWN],
                                  this);
 
-  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] = [](void* data, Evas* evas,
-                                                    Evas_Object* object,
-                                                    void* event_info) {
-    auto* self = static_cast<TizenWindowElementary*>(data);
-    if (self->view_delegate_) {
-      if (self->elm_win_ == object) {
-        auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
-        bool handled = false;
-        if (self->input_method_context_->IsInputPanelShown()) {
-          handled =
-              self->input_method_context_->HandleEvasEventKeyUp(key_event);
+  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP] =
+      [](void* data, Evas* evas, Evas_Object* object, void* event_info) {
+        auto* self = static_cast<TizenWindowElementary*>(data);
+        if (self->view_delegate_) {
+          if (self->elm_win_ == object) {
+            auto* key_event = reinterpret_cast<Evas_Event_Key_Up*>(event_info);
+            bool handled = false;
+            if (self->input_method_context_->IsInputPanelShown()) {
+              handled =
+                  self->input_method_context_->HandleEvasEventKeyUp(key_event);
+            }
+            if (!handled) {
+              self->view_delegate_->OnKey(
+                  key_event->key, key_event->string, key_event->compose,
+                  EvasModifierToEcoreEventModifiers(key_event->modifiers),
+                  key_event->keycode, nullptr, false);
+            }
+          }
         }
-        if (!handled) {
-          self->view_delegate_->OnKey(
-              key_event->key, key_event->string, key_event->compose,
-              EvasModifierToEcoreEventModifiers(key_event->modifiers),
-              key_event->keycode, evas_device_name_get(key_event->dev), false);
-        }
-      }
-    }
-  };
+      };
   evas_object_event_callback_add(elm_win_, EVAS_CALLBACK_KEY_UP,
                                  evas_object_callbacks_[EVAS_CALLBACK_KEY_UP],
                                  this);


### PR DESCRIPTION
This is a feature requested by our customer (3rd-party TV app developer).

To retrieve the name of the last keyboard device used:
```dart
final device = await MethodChannel('tizen/internal/inputdevice')
    .invokeMapMethod<String, dynamic>('getLastUsedKeyboard');
final name = device!['name'] as String;
```
For TV remote controls, the result is either of the following.
- IR remote control: `wt61p807 rc device`
- Smart remote control (bluetooth): `Smart Control [year]`
- Virtual keyboard: `ime` (updated when closing the keyboard)
- Virtual numpad: `virtual key device` (updated on pressing the Done button on Tizen 6.5 or higher, otherwise updated immediately when pressed numbers)

For example, if the developer wants to detect whether the user used a virtual numpad to enter a number, they can compare the string with `virtual key device`.