### PR TITLE
[ci] Update LLVM 12 to 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           src/tools/gn \
             --target-cpu ${{ matrix.arch }} \
-            --target-toolchain /usr/lib/llvm-12 \
+            --target-toolchain /usr/lib/llvm-15 \
             --target-dir build
           ninja -C src/out/build
 
@@ -61,7 +61,7 @@ jobs:
         run: |
           src/tools/gn \
             --target-cpu ${{ matrix.arch }} \
-            --target-toolchain /usr/lib/llvm-12 \
+            --target-toolchain /usr/lib/llvm-15 \
             --target-sysroot src/sysroot-6.5/${{ matrix.arch }} \
             --api-version 6.5 --system-cxx \
             --target-dir build

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Flutter embedder for Tizen.
 - Linux (x64)
 - [depot_tools](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up)
 - [LLVM](https://apt.llvm.org) (10 or later)
-  - `sudo apt install clang-12`
+  - `sudo apt install clang-15`
 - Additional dependencies
   - `sudo apt install git python3 rpm2cpio cpio`
   - `sudo apt install binutils-arm-linux-gnueabi binutils-aarch64-linux-gnu binutils-i686-linux-gnu`
@@ -37,21 +37,21 @@ The Flutter embedder for Tizen.
 - **For arm**
 
   ```sh
-  tools/gn --target-cpu arm --target-toolchain /usr/lib/llvm-12
+  tools/gn --target-cpu arm --target-toolchain /usr/lib/llvm-15
   ninja -C out/tizen_arm
   ```
 
 - **For arm64**
 
   ```sh
-  tools/gn --target-cpu arm64 --target-toolchain /usr/lib/llvm-12
+  tools/gn --target-cpu arm64 --target-toolchain /usr/lib/llvm-15
   ninja -C out/tizen_arm64
   ```
 
 - **For x86**
 
   ```sh
-  tools/gn --target-cpu x86 --target-toolchain /usr/lib/llvm-12
+  tools/gn --target-cpu x86 --target-toolchain /usr/lib/llvm-15
   ninja -C out/tizen_x86
   ```
 


### PR DESCRIPTION
clang version in ubuntu-latest(github action) changed from 12 to 13.
At least version 13 or higher should be used.
