### PR TITLE
[ci] Add clang-12 to build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm2cpio cpio binutils-${{ matrix.triple }}
+          sudo apt-get install -y clang-12 rpm2cpio cpio binutils-${{ matrix.triple }}
 
       - name: Install depot_tools
         run: |


### PR DESCRIPTION
clang 12 has been removed from ubuntu-latest(22.04).
https://github.com/actions/runner-images/issues/8263