### PR TITLE
Implement FlutterDesktopViewGetResourceId

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -240,6 +240,11 @@ void* FlutterDesktopViewGetNativeHandle(FlutterDesktopViewRef view_ref) {
   return view->tizen_view()->GetNativeHandle();
 }
 
+uint32_t FlutterDesktopViewGetResourceId(FlutterDesktopViewRef view_ref) {
+  flutter::FlutterTizenView* view = ViewFromHandle(view_ref);
+  return view->tizen_view()->GetResourceId();
+}
+
 void FlutterDesktopViewResize(FlutterDesktopViewRef view,
                               int32_t width,
                               int32_t height) {

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -204,6 +204,10 @@ FLUTTER_EXPORT void FlutterDesktopViewDestroy(FlutterDesktopViewRef view);
 FLUTTER_EXPORT void* FlutterDesktopViewGetNativeHandle(
     FlutterDesktopViewRef view);
 
+// Returns the resource id of current window.
+FLUTTER_EXPORT uint32_t
+FlutterDesktopViewGetResourceId(FlutterDesktopViewRef view);
+
 // Resizes the view.
 // @warning This API is a work-in-progress and may change.
 FLUTTER_EXPORT void FlutterDesktopViewResize(FlutterDesktopViewRef view,

--- a/flutter/shell/platform/tizen/tizen_view_base.h
+++ b/flutter/shell/platform/tizen/tizen_view_base.h
@@ -35,13 +35,13 @@ class TizenViewBase {
   // Returns the geometry of the view.
   virtual TizenGeometry GetGeometry() = 0;
 
-  virtual uint32_t GetResourceId() = 0;
-
   // Set the geometry of the view.
   virtual bool SetGeometry(TizenGeometry geometry) = 0;
 
   // Returns the dpi of the screen.
   virtual int32_t GetDpi() = 0;
+
+  virtual uint32_t GetResourceId() = 0;
 
   virtual void UpdateFlutterCursor(const std::string& kind) = 0;
 

--- a/flutter/shell/platform/tizen/tizen_view_base.h
+++ b/flutter/shell/platform/tizen/tizen_view_base.h
@@ -35,6 +35,8 @@ class TizenViewBase {
   // Returns the geometry of the view.
   virtual TizenGeometry GetGeometry() = 0;
 
+  virtual uint32_t GetResourceId() = 0;
+
   // Set the geometry of the view.
   virtual bool SetGeometry(TizenGeometry geometry) = 0;
 

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -362,6 +362,10 @@ uintptr_t TizenViewElementary::GetWindowId() {
       ecore_evas_ecore_evas_get(evas_object_evas_get(container_)));
 }
 
+uint32_t TizenViewElementary::GetResourceId(){
+  return 0;
+}
+
 void TizenViewElementary::Show() {
   evas_object_show(container_);
   evas_object_show(image_);

--- a/flutter/shell/platform/tizen/tizen_view_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.cc
@@ -362,7 +362,7 @@ uintptr_t TizenViewElementary::GetWindowId() {
       ecore_evas_ecore_evas_get(evas_object_evas_get(container_)));
 }
 
-uint32_t TizenViewElementary::GetResourceId(){
+uint32_t TizenViewElementary::GetResourceId() {
   return 0;
 }
 

--- a/flutter/shell/platform/tizen/tizen_view_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_view_elementary.h
@@ -35,6 +35,8 @@ class TizenViewElementary : public TizenView {
 
   uintptr_t GetWindowId() override;
 
+  uint32_t GetResourceId() override;
+
   void Show() override;
 
   void UpdateFlutterCursor(const std::string& kind) override;

--- a/flutter/shell/platform/tizen/tizen_view_nui.cc
+++ b/flutter/shell/platform/tizen/tizen_view_nui.cc
@@ -66,6 +66,10 @@ uintptr_t TizenViewNui::GetWindowId() {
   return default_window_id_;
 }
 
+uint32_t TizenViewNui::GetResourceId() {
+  return 0;
+}
+
 void TizenViewNui::Show() {
   // Do nothing.
 }

--- a/flutter/shell/platform/tizen/tizen_view_nui.h
+++ b/flutter/shell/platform/tizen/tizen_view_nui.h
@@ -38,6 +38,8 @@ class TizenViewNui : public TizenView {
 
   uintptr_t GetWindowId() override;
 
+  uint32_t GetResourceId() override;
+
   void Show() override;
 
   void RequestRendering();

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -466,7 +466,11 @@ void HandleResourceId(void* data, tizen_resource* tizen_resource, uint32_t id) {
 }
 
 uint32_t TizenWindowEcoreWl2::GetResourceId() {
-  wl_registry* registry = ecore_wl2_display_registry_get(ecore_wl2_display_);
+  if (resource_id_ > 0) {
+    return resource_id_;
+  }
+  struct wl_registry* registry =
+      ecore_wl2_display_registry_get(ecore_wl2_display_);
   if (!registry) {
     FT_LOG(Error) << "Could not retreive wl_registry from the display.";
     return 0;
@@ -499,7 +503,6 @@ uint32_t TizenWindowEcoreWl2::GetResourceId() {
     return 0;
   }
 
-  uint32_t resource_id = 0;
   struct wl_event_queue* event_queue = wl_display_create_queue(wl2_display_);
   if (!event_queue) {
     FT_LOG(Error) << "Failed to create wl_event_queue.";
@@ -507,13 +510,13 @@ uint32_t TizenWindowEcoreWl2::GetResourceId() {
     tizen_surface_destroy(surface);
     return 0;
   }
-  wl_proxy_set_queue((struct wl_proxy*)resource, event_queue);
-  tizen_resource_add_listener(resource, &tz_resource_listener, &resource_id);
+  wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(resource), event_queue);
+  tizen_resource_add_listener(resource, &tz_resource_listener, &resource_id_);
   wl_display_roundtrip_queue(wl2_display_, event_queue);
   tizen_resource_destroy(resource);
   tizen_surface_destroy(surface);
   wl_event_queue_destroy(event_queue);
-  return resource_id;
+  return resource_id_;
 }
 
 void TizenWindowEcoreWl2::SetPreferredOrientations(

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -160,9 +160,9 @@ void TizenWindowEcoreWl2::EnableCursor() {
   }
 
   // These functions are defined in vd-win-util's cursor_module.h.
-  int (*CursorModule_Initialize)(wl_display * display, wl_registry * registry,
-                                 wl_seat * seat, unsigned int id);
-  int (*Cursor_Set_Config)(wl_surface * surface, uint32_t config_type,
+  int (*CursorModule_Initialize)(wl_display* display, wl_registry* registry,
+                                 wl_seat* seat, unsigned int id);
+  int (*Cursor_Set_Config)(wl_surface* surface, uint32_t config_type,
                            void* data);
   void (*CursorModule_Finalize)(void);
   *(void**)(&CursorModule_Initialize) =

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
@@ -44,6 +44,8 @@ class TizenWindowEcoreWl2 : public TizenWindow {
 
   uintptr_t GetWindowId() override;
 
+  uint32_t GetResourceId() override;
+
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
 
   void BindKeys(const std::vector<std::string>& keys) override;

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
@@ -79,6 +79,7 @@ class TizenWindowEcoreWl2 : public TizenWindow {
   std::vector<Ecore_Event_Handler*> ecore_event_handlers_;
 
   tizen_policy* tizen_policy_ = nullptr;
+  uint32_t resource_id_ = 0;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -413,6 +413,10 @@ uintptr_t TizenWindowElementary::GetWindowId() {
       ecore_evas_ecore_evas_get(evas_object_evas_get(elm_win_)));
 }
 
+uint32_t TizenWindowElementary::GetResourceId() {
+  return 0;
+}
+
 void TizenWindowElementary::SetPreferredOrientations(
     const std::vector<int>& rotations) {
   elm_win_wm_rotation_available_rotations_set(elm_win_, rotations.data(),

--- a/flutter/shell/platform/tizen/tizen_window_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.h
@@ -45,6 +45,8 @@ class TizenWindowElementary : public TizenWindow {
 
   uintptr_t GetWindowId() override;
 
+  uint32_t GetResourceId() override;
+
   void SetPreferredOrientations(const std::vector<int>& rotations) override;
 
   void BindKeys(const std::vector<std::string>& keys) override;


### PR DESCRIPTION
Replace surface id with resource id for fixing overlap issue on Tizen TV  6.0. 