### PR TITLE
Prevent possible race condition in NotifyAppControl

### DIFF
--- a/flutter/shell/platform/tizen/channels/app_control.h
+++ b/flutter/shell/platform/tizen/channels/app_control.h
@@ -120,8 +120,13 @@ class AppControlManager {
     return instance;
   }
 
-  void Insert(std::unique_ptr<AppControl> app_control) {
-    map_.insert({app_control->id(), std::move(app_control)});
+  // Returns a pointer to the inserted element if successful, otherwise nullptr.
+  AppControl* Insert(std::unique_ptr<AppControl> app_control) {
+    auto iter = map_.emplace(app_control->id(), std::move(app_control));
+    if (iter.second) {
+      return iter.first->second.get();
+    }
+    return nullptr;
   }
 
   void Remove(int32_t id) { map_.erase(id); }

--- a/flutter/shell/platform/tizen/channels/app_control_channel.cc
+++ b/flutter/shell/platform/tizen/channels/app_control_channel.cc
@@ -58,13 +58,18 @@ void AppControlChannel::NotifyAppControl(void* handle) {
     FT_LOG(Error) << "Could not create an instance of AppControl.";
     return;
   }
+  AppControl* app_control_ptr =
+      AppControlManager::GetInstance().Insert(std::move(app_control));
+  if (!app_control_ptr) {
+    FT_LOG(Error) << "The handle already exists.";
+    return;
+  }
   if (event_sink_) {
-    SendAppControlEvent(app_control.get());
+    SendAppControlEvent(app_control_ptr);
   } else {
     FT_LOG(Info) << "No event channel has been set up.";
-    queue_.push(app_control.get());
+    queue_.push(app_control_ptr);
   }
-  AppControlManager::GetInstance().Insert(std::move(app_control));
 }
 
 void AppControlChannel::HandleMethodCall(


### PR DESCRIPTION
`AppControlManager` is not thread-safe and may cause the following exception (reported by a third-party developer) when the UI thread (Dart code) is notified of an app control event (by `NotifyAppControl`) and tries to access the associated app control instance through `NativeAttachAppControl` before the instance is added to `AppControlManager` on the platform thread.

```dart
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Exception: Could not find an instance of AppControl with ID 1.
#0      new AppControl._fromMap (package:tizen_app_control/src/app_control.dart:88:7)
#1      new ReceivedAppControl._fromMap (package:tizen_app_control/src/app_control.dart:263:15)
#2      AppControl.onAppControl.<anonymous closure> (package:tizen_app_control/src/app_control.dart:141:50)
#3      _MapStream._handleData (dart:async/stream_pipe.dart:213:31)
#4      _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:153:13)
#5      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
```

I'm not sure if this will fix the error. Let me just give it a try.