### PR TITLE
[ci] Fix check-symbol action fail

### DIFF
--- a/.github/workflows/check-symbols.yml
+++ b/.github/workflows/check-symbols.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
         with:
           repository: flutter-tizen/tizen_allowlist
           token: ${{ secrets.TIZENAPI_TOKEN }}


### PR DESCRIPTION
This change adds missing code from the 3.19 update.
https://github.com/flutter-tizen/embedder/pull/57

This PR is valid until https://github.com/flutter-tizen/embedder/pull/58 is applied.