### PR TITLE
Add view_id for FlutterPointerEvent

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -218,7 +218,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
 #endif
   }
 
-  auto view = std::make_unique<flutter::FlutterTizenView>(std::move(window));
+  auto view = std::make_unique<flutter::FlutterTizenView>(
+      flutter::kImplicitViewId, std::move(window));
 
   // Take ownership of the engine, starting it if necessary.
   view->SetEngine(

--- a/flutter/shell/platform/tizen/flutter_tizen_elementary.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_elementary.cc
@@ -30,8 +30,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromElmParent(
           view_properties.width, view_properties.height,
           static_cast<Evas_Object*>(parent));
 
-  auto view =
-      std::make_unique<flutter::FlutterTizenView>(std::move(tizen_view));
+  auto view = std::make_unique<flutter::FlutterTizenView>(
+      flutter::kImplicitViewId, std::move(tizen_view));
 
   // Take ownership of the engine, starting it if necessary.
   view->SetEngine(

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -45,6 +45,12 @@ struct FlutterDesktopMessenger {
 
 namespace flutter {
 
+// The view ID for a single-view Flutter app.
+//
+// See:
+// https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html
+constexpr FlutterViewId kImplicitViewId = 0;
+
 class FlutterTizenView;
 
 // Manages state associated with the underlying FlutterEngine.

--- a/flutter/shell/platform/tizen/flutter_tizen_nui.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_nui.cc
@@ -39,8 +39,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromImageView(
           reinterpret_cast<Dali::NativeImageSourceQueue*>(native_image_queue),
           default_window_id);
 
-  auto view =
-      std::make_unique<flutter::FlutterTizenView>(std::move(tizen_view));
+  auto view = std::make_unique<flutter::FlutterTizenView>(
+      flutter::kImplicitViewId, std::move(tizen_view));
 
   // Take ownership of the engine, starting it if necessary.
   view->SetEngine(

--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -66,8 +66,9 @@ double ComputePixelRatio(flutter::TizenViewBase* view) {
 
 namespace flutter {
 
-FlutterTizenView::FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view)
-    : tizen_view_(std::move(tizen_view)) {
+FlutterTizenView::FlutterTizenView(FlutterViewId view_id,
+                                   std::unique_ptr<TizenViewBase> tizen_view)
+    : view_id_(view_id), tizen_view_(std::move(tizen_view)) {
   tizen_view_->SetView(this);
 
   if (auto* window = dynamic_cast<TizenWindow*>(tizen_view_.get())) {
@@ -442,6 +443,7 @@ void FlutterTizenView::SendFlutterPointerEvent(FlutterPointerPhase phase,
     event.device = state->pointer_id;
     event.device_kind = state->device_kind;
     event.buttons = state->buttons;
+    event.view_id = view_id();
     engine_->SendPointerEvent(event);
 
     state->flutter_state_is_added = true;
@@ -461,6 +463,7 @@ void FlutterTizenView::SendFlutterPointerEvent(FlutterPointerPhase phase,
   event.device = state->pointer_id;
   event.device_kind = state->device_kind;
   event.buttons = state->buttons;
+  event.view_id = view_id();
   engine_->SendPointerEvent(event);
 }
 

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -25,9 +25,13 @@ namespace flutter {
 
 class FlutterTizenView : public TizenViewEventHandlerDelegate {
  public:
-  FlutterTizenView(std::unique_ptr<TizenViewBase> tizen_view);
+  FlutterTizenView(FlutterViewId view_id,
+                   std::unique_ptr<TizenViewBase> tizen_view);
 
   virtual ~FlutterTizenView();
+
+  // Get the view's unique identifier.
+  FlutterViewId view_id() const { return view_id_; }
 
   // Configures the window instance with an instance of a running Flutter
   // engine.
@@ -169,6 +173,9 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
 
   // The engine associated with this view.
   std::unique_ptr<FlutterTizenEngine> engine_;
+
+  // The view's unique identifier.
+  FlutterViewId view_id_;
 
   // The platform view associated with this Flutter view.
   std::unique_ptr<TizenViewBase> tizen_view_;


### PR DESCRIPTION
This PR adds a new field `view_id` to embedder API's `FlutterPointerEvent`,
allowing platforms to specify the source view of pointer events.