### PR TITLE
Add 8.0 to artifact creation version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        api-version: [5.5, 6.5]
+        api-version: [5.5, 6.5, 8.0]
         arch: [arm, arm64, x86]
         include:
           - arch: arm
@@ -47,6 +47,10 @@ jobs:
         if: ${{ matrix.api-version == 6.5 }}
         run: src/tools/generate_sysroot.py --api-version 6.5 --out src/sysroot-6.5
 
+      - name: Generate Tizen 8.0 sysroot
+        if: ${{ matrix.api-version == 8 }}
+        run: src/tools/generate_sysroot.py --api-version 8.0 --out src/sysroot-8.0
+
       - name: Build for Tizen 5.5
         if: ${{ matrix.api-version == 5.5 }}
         run: |
@@ -64,6 +68,17 @@ jobs:
             --target-toolchain /usr/lib/llvm-12 \
             --target-sysroot src/sysroot-6.5/${{ matrix.arch }} \
             --api-version 6.5 --system-cxx \
+            --target-dir build
+          ninja -C src/out/build
+          
+      - name: Build for Tizen 8.0
+        if: ${{ matrix.api-version == 8 }}
+        run: |
+          src/tools/gn \
+            --target-cpu ${{ matrix.arch }} \
+            --target-toolchain /usr/lib/llvm-12 \
+            --target-sysroot src/sysroot-8.0/${{ matrix.arch }} \
+            --api-version 8.0 --system-cxx \
             --target-dir build
           ninja -C src/out/build
 

--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -170,8 +170,8 @@ template("embedder") {
       ]
     }
 
-    if (target_name == "flutter_tizen_mobile" ||
-        target_name == "flutter_tizen_common") {
+    if ((target_name == "flutter_tizen_mobile" ||
+         target_name == "flutter_tizen_common") && api_version != "8.0") {
       libs += [ "cbhm" ]
     }
 
@@ -190,6 +190,10 @@ template("embedder") {
       ]
 
       defines += [ "NUI_SUPPORT" ]
+    }
+
+    if (api_version == "8.0") {
+      defines += [ "TIZEN_VERSION_8_0" ]
     }
 
     configs += [

--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -81,7 +81,8 @@ PlatformChannel::PlatformChannel(BinaryMessenger* messenger,
           kChannelName,
           &JsonMethodCodec::GetInstance())),
       view_(view) {
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   int ret = cbhm_open_service(&cbhm_handle_);
   if (ret != CBHM_ERROR_NONE) {
     FT_LOG(Error) << "Failed to initialize the clipboard service.";
@@ -96,7 +97,8 @@ PlatformChannel::PlatformChannel(BinaryMessenger* messenger,
 }
 
 PlatformChannel::~PlatformChannel() {
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   cbhm_close_service(cbhm_handle_);
 #endif
 }
@@ -233,7 +235,8 @@ void PlatformChannel::HapticFeedbackVibrate(const std::string& feedback_type) {
 void PlatformChannel::GetClipboardData(ClipboardCallback on_data) {
   on_clipboard_data_ = std::move(on_data);
 
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   int ret = cbhm_selection_get(
       cbhm_handle_, CBHM_SEL_TYPE_TEXT,
       [](cbhm_h cbhm_handle, const char* buf, size_t len,
@@ -264,7 +267,8 @@ void PlatformChannel::GetClipboardData(ClipboardCallback on_data) {
 }
 
 void PlatformChannel::SetClipboardData(const std::string& data) {
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   int ret = cbhm_selection_set(cbhm_handle_, CBHM_SEL_TYPE_TEXT, data.c_str(),
                                data.length());
   if (ret != CBHM_ERROR_NONE) {
@@ -276,7 +280,8 @@ void PlatformChannel::SetClipboardData(const std::string& data) {
 }
 
 bool PlatformChannel::ClipboardHasStrings() {
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   return cbhm_item_count_get(cbhm_handle_) > 0;
 #else
   return !clipboard_.empty();

--- a/flutter/shell/platform/tizen/channels/platform_channel.h
+++ b/flutter/shell/platform/tizen/channels/platform_channel.h
@@ -5,7 +5,8 @@
 #ifndef EMBEDDER_PLATFORM_CHANNEL_H_
 #define EMBEDDER_PLATFORM_CHANNEL_H_
 
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
 #include <cbhm.h>
 #endif
 
@@ -53,7 +54,8 @@ class PlatformChannel {
   // A reference to the native view managed by FlutterTizenView.
   TizenViewBase* view_ = nullptr;
 
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
+#if (defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)) && \
+    !defined(TIZEN_VERSION_8_0)
   // The clipboard history manager.
   cbhm_h cbhm_handle_ = nullptr;
 #else

--- a/flutter/third_party/accessibility/ax/platform/ax_platform_atk_hyperlink.cc
+++ b/flutter/third_party/accessibility/ax/platform/ax_platform_atk_hyperlink.cc
@@ -248,11 +248,11 @@ static void AXPlatformAtkHyperlinkInit(AXPlatformAtkHyperlink* self, gpointer) {
 }
 
 GType ax_platform_atk_hyperlink_get_type() {
-  static volatile gsize type_volatile = 0;
+  static gsize type = 0;
 
   AXPlatformNodeAuraLinux::EnsureGTypeInit();
 
-  if (g_once_init_enter(&type_volatile)) {
+  if (g_once_init_enter(&type)) {
     static const GTypeInfo tinfo = {
         sizeof(AXPlatformAtkHyperlinkClass),
         (GBaseInitFunc) nullptr,
@@ -273,10 +273,10 @@ GType ax_platform_atk_hyperlink_get_type() {
     GType type = g_type_register_static(
         ATK_TYPE_HYPERLINK, "AXPlatformAtkHyperlink", &tinfo, GTypeFlags(0));
     g_type_add_interface_static(type, ATK_TYPE_ACTION, &actionInfo);
-    g_once_init_leave(&type_volatile, type);
+    g_once_init_leave(&type, type);
   }
 
-  return type_volatile;
+  return type;
 }
 
 }  // namespace ui

--- a/flutter/third_party/accessibility/ax/platform/ax_platform_node_auralinux.cc
+++ b/flutter/third_party/accessibility/ax/platform/ax_platform_node_auralinux.cc
@@ -2240,8 +2240,8 @@ void ClassInit(gpointer class_pointer, gpointer /* class_data */) {
 GType GetType() {
   AXPlatformNodeAuraLinux::EnsureGTypeInit();
 
-  static volatile gsize type_volatile = 0;
-  if (g_once_init_enter(&type_volatile)) {
+  static gsize type = 0;
+  if (g_once_init_enter(&type)) {
     static const GTypeInfo type_info = {
         sizeof(AXPlatformNodeAuraLinuxClass),  // class_size
         nullptr,                               // base_init
@@ -2257,10 +2257,10 @@ GType GetType() {
 
     GType type = g_type_register_static(
         ATK_TYPE_OBJECT, "AXPlatformNodeAuraLinux", &type_info, GTypeFlags(0));
-    g_once_init_leave(&type_volatile, type);
+    g_once_init_leave(&type, type);
   }
 
-  return type_volatile;
+  return type;
 }
 
 void Detach(AXPlatformNodeAuraLinuxObject* atk_object) {


### PR DESCRIPTION
`cbhm` library has been deprecated in Tizen 8.0.
So, In common profile build was fail.
Supports creation of 8.0 artifact excluding `cbhm`.