### PR TITLE
Remove cbhm dependency

### DIFF
--- a/flutter/shell/platform/tizen/BUILD.gn
+++ b/flutter/shell/platform/tizen/BUILD.gn
@@ -13,7 +13,6 @@ config("flutter_tizen_config") {
   include_dirs = [
     "${sysroot_path}/usr/include/appfw",
     "${sysroot_path}/usr/include/base",
-    "${sysroot_path}/usr/include/cbhm",
     "${sysroot_path}/usr/include/dali",
     "${sysroot_path}/usr/include/dali-adaptor",
     "${sysroot_path}/usr/include/dali-toolkit",
@@ -168,11 +167,6 @@ template("embedder") {
         "tzsh_common",
         "tzsh_softkey",
       ]
-    }
-
-    if (target_name == "flutter_tizen_mobile" ||
-        target_name == "flutter_tizen_common") {
-      libs += [ "cbhm" ]
     }
 
     defines += invoker.defines

--- a/flutter/shell/platform/tizen/channels/platform_channel.h
+++ b/flutter/shell/platform/tizen/channels/platform_channel.h
@@ -5,10 +5,6 @@
 #ifndef EMBEDDER_PLATFORM_CHANNEL_H_
 #define EMBEDDER_PLATFORM_CHANNEL_H_
 
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
-#include <cbhm.h>
-#endif
-
 #include <functional>
 #include <memory>
 #include <string>
@@ -53,18 +49,10 @@ class PlatformChannel {
   // A reference to the native view managed by FlutterTizenView.
   TizenViewBase* view_ = nullptr;
 
-#if defined(MOBILE_PROFILE) || defined(COMMON_PROFILE)
-  // The clipboard history manager.
-  cbhm_h cbhm_handle_ = nullptr;
-#else
   // A container that holds clipboard data during the engine lifetime.
   //
-  // Only used by profiles that do not support the Tizen clipboard API
-  // (wearable and TV).
+  // TODO(JSUYA): Remove after implementing the ecore_wl2 based clipboard.
   std::string clipboard_;
-#endif
-
-  ClipboardCallback on_clipboard_data_ = nullptr;
 };
 
 }  // namespace flutter

--- a/tools/generate_sysroot.py
+++ b/tools/generate_sysroot.py
@@ -43,8 +43,6 @@ unified_packages = [
   'capi-system-system-settings-devel',
   'capi-ui-efl-util',
   'capi-ui-efl-util-devel',
-  'cbhm',
-  'cbhm-devel',
   'coregl',
   'coregl-devel',
   'ecore-con-devel',


### PR DESCRIPTION
cbhm library has been deprecated in Tizen 8.0.
Therefore, remove cbhm related code.
Copy&paste between applications is not supported for the time being in common and mobile profile.
(Copy&paste within applications is still supported.)
This feature will be supported again using the ecore_wl2 API.