### PR TITLE
[a11y] Add eldbus initialization

### DIFF
--- a/flutter/shell/platform/tizen/channels/accessibility_channel.cc
+++ b/flutter/shell/platform/tizen/channels/accessibility_channel.cc
@@ -50,6 +50,8 @@ AccessibilityChannel::AccessibilityChannel(BinaryMessenger* messenger)
           messenger,
           kChannelName,
           &StandardMessageCodec::GetInstance())) {
+  eldbus_init();
+
   session_bus_ = eldbus_connection_get(ELDBUS_CONNECTION_TYPE_SESSION);
   bus_ = eldbus_object_get(session_bus_, kAccessibilityDbus,
                            kAccessibilityDbusPath);
@@ -92,6 +94,8 @@ AccessibilityChannel::~AccessibilityChannel() {
   eldbus_connection_unref(accessibility_bus_);
   eldbus_connection_unref(session_bus_);
   eldbus_object_unref(bus_);
+
+  eldbus_shutdown();
 }
 
 }  // namespace flutter


### PR DESCRIPTION
There is case where a crash occurs because eldbus is not initialized in RPI.
To prevent this, initialization and shutdown are added.