### PR TITLE
Set rotations properly for landscape default devices

### DIFF
--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -326,12 +326,23 @@ void PlatformChannel::SetEnabledSystemUiOverlays(
 void PlatformChannel::SetPreferredOrientations(
     const std::vector<std::string>& orientations) {
   if (auto* window = dynamic_cast<TizenWindow*>(view_)) {
-    static const std::map<std::string, int> orientation_mapping = {
-        {kPortraitUp, 0},
-        {kLandscapeLeft, 90},
-        {kPortraitDown, 180},
-        {kLandscapeRight, 270},
-    };
+    std::map<std::string, int> orientation_mapping;
+    TizenGeometry geometry = window->GetGeometry();
+    if (geometry.width > geometry.height) {
+      orientation_mapping = {
+          {kLandscapeLeft, 0},
+          {kPortraitDown, 90},
+          {kLandscapeRight, 180},
+          {kPortraitUp, 270},
+      };
+    } else {
+      orientation_mapping = {
+          {kPortraitUp, 0},
+          {kLandscapeLeft, 90},
+          {kPortraitDown, 180},
+          {kLandscapeRight, 270},
+      };
+    }
     std::vector<int> rotations;
     for (const auto& orientation : orientations) {
       rotations.push_back(orientation_mapping.at(orientation));

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -142,7 +142,11 @@ void TizenWindowEcoreWl2::SetWindowOptions() {
   ecore_wl2_indicator_visible_type_set(ecore_wl2_window_,
                                        ECORE_WL2_INDICATOR_VISIBLE_TYPE_SHOWN);
 
+#ifdef TV_PROFILE
+  int rotations[1] = {0};  // Default is only landscape.
+#else
   int rotations[4] = {0, 90, 180, 270};
+#endif
   ecore_wl2_window_available_rotations_set(ecore_wl2_window_, rotations,
                                            sizeof(rotations) / sizeof(int));
 


### PR DESCRIPTION
+) https://github.com/flutter-tizen/embedder/issues/19

+)Set only landscape as default for TV profile.

For [webapps on TV devices](https://developer.samsung.com/smarttv/develop/guides/sero-guide.html), the default orientation setting is landscape only. This keep the output screen to be display to landscape even if the physical device is portrait mode.
To behave according to the device's orientation(like "all" as webapp, the user can call SystemChrome.setPreferredOrientations() from the app to set it.

```
SystemChrome.setPreferredOrientations([
      DeviceOrientation.portraitDown,
      DeviceOrientation.portraitUp,
      DeviceOrientation.landscapeLeft,
      DeviceOrientation.landscapeRight,
    ]);
```
