### PR TITLE
Add user-defined pixel ratio

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -213,7 +213,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
   }
 
   auto view = std::make_unique<flutter::FlutterTizenView>(
-      flutter::kImplicitViewId, std::move(window));
+      flutter::kImplicitViewId, std::move(window),
+      window_properties.user_pixel_ratio);
 
   // Take ownership of the engine, starting it if necessary.
   view->SetEngine(

--- a/flutter/shell/platform/tizen/flutter_tizen_view.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.h
@@ -26,7 +26,8 @@ namespace flutter {
 class FlutterTizenView : public TizenViewEventHandlerDelegate {
  public:
   FlutterTizenView(FlutterViewId view_id,
-                   std::unique_ptr<TizenViewBase> tizen_view);
+                   std::unique_ptr<TizenViewBase> tizen_view,
+                   double user_pixel_ratio = 0);
 
   virtual ~FlutterTizenView();
 
@@ -210,6 +211,8 @@ class FlutterTizenView : public TizenViewEventHandlerDelegate {
   // The current view transformation.
   FlutterTransformation flutter_transformation_ = {1.0, 0.0, 0.0, 0.0, 1.0,
                                                    0.0, 0.0, 0.0, 1.0};
+  // The user-defined pixel ratio.
+  double user_pixel_ratio_ = 0;
 };
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -65,6 +65,8 @@ typedef struct {
   FlutterDesktopRendererType renderer_type;
   // The external output type of the window.
   FlutterDesktopExternalOutputType external_output_type;
+  // The user-defined pixel ratio.
+  double user_pixel_ratio;
 } FlutterDesktopWindowProperties;
 
 // Properties for configuring the initial settings of a Flutter view.


### PR DESCRIPTION
Previously, we used values calculated through Base scale calculation using DPI and DeviceFactor used in Tizen.
Since it follows Tizen UX, it can show the same look as other apps on TV. (https://docs.tizen.org/application/native/guides/ui/efl/multiple-screens/)
However, when running an app written for another platform on Tizen, the scale may appear different.
So I add user_pixel_ratio to WindowProperty to allow the user to adjust this scale.