### PR TITLE
Using precreated window

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -209,7 +209,8 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
   } else {
     window = std::make_unique<flutter::TizenWindowEcoreWl2>(
         window_geometry, window_properties.transparent,
-        window_properties.focusable, window_properties.top_level);
+        window_properties.focusable, window_properties.top_level,
+        window_properties.window_handle);
   }
 
   auto view = std::make_unique<flutter::FlutterTizenView>(

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -67,6 +67,8 @@ typedef struct {
   FlutterDesktopExternalOutputType external_output_type;
   // The user-defined pixel ratio.
   double user_pixel_ratio;
+  // The precreated window handle.
+  void* window_handle;
 } FlutterDesktopWindowProperties;
 
 // Properties for configuring the initial settings of a Flutter view.

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -52,9 +52,10 @@ FlutterPointerDeviceKind ToFlutterDeviceKind(const Ecore_Device* dev) {
 TizenWindowEcoreWl2::TizenWindowEcoreWl2(TizenGeometry geometry,
                                          bool transparent,
                                          bool focusable,
-                                         bool top_level)
+                                         bool top_level,
+                                         void* window_handle = nullptr)
     : TizenWindow(geometry, transparent, focusable, top_level) {
-  if (!CreateWindow()) {
+  if (!CreateWindow(window_handle)) {
     FT_LOG(Error) << "Failed to create a platform window.";
     return;
   }
@@ -70,7 +71,7 @@ TizenWindowEcoreWl2::~TizenWindowEcoreWl2() {
   DestroyWindow();
 }
 
-bool TizenWindowEcoreWl2::CreateWindow() {
+bool TizenWindowEcoreWl2::CreateWindow(void* window_handle) {
   if (!ecore_wl2_init()) {
     FT_LOG(Error) << "Could not initialize Ecore Wl2.";
     return false;
@@ -99,9 +100,14 @@ bool TizenWindowEcoreWl2::CreateWindow() {
     initial_geometry_.height = height;
   }
 
-  ecore_wl2_window_ = ecore_wl2_window_new(
-      ecore_wl2_display_, nullptr, initial_geometry_.left,
-      initial_geometry_.top, initial_geometry_.width, initial_geometry_.height);
+  if (window_handle == nullptr) {
+    ecore_wl2_window_ =
+        ecore_wl2_window_new(ecore_wl2_display_, nullptr,
+                             initial_geometry_.left, initial_geometry_.top,
+                             initial_geometry_.width, initial_geometry_.height);
+  } else {
+    ecore_wl2_window_ = static_cast<Ecore_Wl2_Window*>(window_handle);
+  }
 
   ecore_wl2_egl_window_ = ecore_wl2_egl_window_create(
       ecore_wl2_window_, initial_geometry_.width, initial_geometry_.height);

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
@@ -22,7 +22,8 @@ class TizenWindowEcoreWl2 : public TizenWindow {
   TizenWindowEcoreWl2(TizenGeometry geometry,
                       bool transparent,
                       bool focusable,
-                      bool top_level);
+                      bool top_level,
+                      void* window_handle);
 
   ~TizenWindowEcoreWl2();
 
@@ -55,7 +56,7 @@ class TizenWindowEcoreWl2 : public TizenWindow {
   void UpdateFlutterCursor(const std::string& kind) override;
 
  private:
-  bool CreateWindow();
+  bool CreateWindow(void* window_handle);
 
   void DestroyWindow();
 


### PR DESCRIPTION
If there is a window handle passed in from embedding, use it.
This window handle is a pre-created window and can get by functions implemented in NUI(Dali).
In elementary windows(elm_win) case, there is no plan.