### PR TITLE
[a11y] AXPlatformNodeBase::GetIndexInParent: Remove BASE_UNREACHABLE

### DIFF
--- a/flutter/third_party/accessibility/ax/platform/ax_platform_node_base.cc
+++ b/flutter/third_party/accessibility/ax/platform/ax_platform_node_base.cc
@@ -166,7 +166,6 @@ std::optional<int> AXPlatformNodeBase::GetIndexInParent() {
 
   BASE_LOG()
       << "Unable to find the child in the list of its parent's children.";
-  BASE_UNREACHABLE();
   return std::nullopt;
 }
 


### PR DESCRIPTION
Fix : #91 
Refer to : https://chromium-review.googlesource.com/c/chromium/src/+/4418610