### PR TITLE
Drop use of volatile with g_once_*()

### DIFF
--- a/flutter/third_party/accessibility/ax/platform/ax_platform_atk_hyperlink.cc
+++ b/flutter/third_party/accessibility/ax/platform/ax_platform_atk_hyperlink.cc
@@ -248,11 +248,11 @@ static void AXPlatformAtkHyperlinkInit(AXPlatformAtkHyperlink* self, gpointer) {
 }
 
 GType ax_platform_atk_hyperlink_get_type() {
-  static volatile gsize type_volatile = 0;
+  static gsize type_id = 0;
 
   AXPlatformNodeAuraLinux::EnsureGTypeInit();
 
-  if (g_once_init_enter(&type_volatile)) {
+  if (g_once_init_enter(&type_id)) {
     static const GTypeInfo tinfo = {
         sizeof(AXPlatformAtkHyperlinkClass),
         (GBaseInitFunc) nullptr,
@@ -273,10 +273,10 @@ GType ax_platform_atk_hyperlink_get_type() {
     GType type = g_type_register_static(
         ATK_TYPE_HYPERLINK, "AXPlatformAtkHyperlink", &tinfo, GTypeFlags(0));
     g_type_add_interface_static(type, ATK_TYPE_ACTION, &actionInfo);
-    g_once_init_leave(&type_volatile, type);
+    g_once_init_leave(&type_id, type);
   }
 
-  return type_volatile;
+  return type_id;
 }
 
 }  // namespace ui

--- a/flutter/third_party/accessibility/ax/platform/ax_platform_node_auralinux.cc
+++ b/flutter/third_party/accessibility/ax/platform/ax_platform_node_auralinux.cc
@@ -2248,8 +2248,8 @@ void ClassInit(gpointer class_pointer, gpointer /* class_data */) {
 GType GetType() {
   AXPlatformNodeAuraLinux::EnsureGTypeInit();
 
-  static volatile gsize type_volatile = 0;
-  if (g_once_init_enter(&type_volatile)) {
+  static gsize type_id = 0;
+  if (g_once_init_enter(&type_id)) {
     static const GTypeInfo type_info = {
         sizeof(AXPlatformNodeAuraLinuxClass),  // class_size
         nullptr,                               // base_init
@@ -2265,10 +2265,10 @@ GType GetType() {
 
     GType type = g_type_register_static(
         ATK_TYPE_OBJECT, "AXPlatformNodeAuraLinux", &type_info, GTypeFlags(0));
-    g_once_init_leave(&type_volatile, type);
+    g_once_init_leave(&type_id, type);
   }
 
-  return type_volatile;
+  return type_id;
 }
 
 void Detach(AXPlatformNodeAuraLinuxObject* atk_object) {


### PR DESCRIPTION
The variables here are only marked as volatile because they’re arguments to `g_once_*()`.

Related chromium commit:
https://chromium-review.googlesource.com/c/chromium/src/+/3960017
Related glib commit:
https://github.com/GNOME/glib/commit/fab561f8d0