### PR TITLE
Support gcc 14.2.0 on tizen 10.0

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -131,11 +131,21 @@ config("system_cxx") {
     assert(false, "Unknown target_cpu: " + target_cpu)
   }
 
-  include_dirs = [
-    "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include",
-    "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include/c++",
-    "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include/c++/${gcc_target_triple}",
-  ]
+  include_dirs = []
+  if (api_version == "10.0") {
+    include_dirs += [
+        "${lib_path}/gcc/${gcc_target_triple}/14.2.0/include",
+        "${lib_path}/gcc/${gcc_target_triple}/14.2.0/include/c++",
+        "${lib_path}/gcc/${gcc_target_triple}/14.2.0/include/c++/${gcc_target_triple}",
+      ]
+  } else {
+    include_dirs += [
+        "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include",
+        "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include/c++",
+        "${lib_path}/gcc/${gcc_target_triple}/9.2.0/include/c++/${gcc_target_triple}",
+      ]
+  }
+
   libs = [ "stdc++" ]
 }
 


### PR DESCRIPTION
Tizen toolchain version has been upgraded.
Starting with Tizen 10.0, gcc has been upgraded to 14.2.0.
(Tizen 6.0 ~ 9.0 version use gcc v9.2.0.)