### PR TITLE
Add EXT function to egl proxy resolver

### DIFF
--- a/flutter/shell/platform/tizen/tizen_renderer_egl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_egl.cc
@@ -443,6 +443,13 @@ void* TizenRendererEgl::OnProcResolver(const char* name) {
   GL_FUNC(glVertexAttrib4fv)
   GL_FUNC(glVertexAttribPointer)
   GL_FUNC(glViewport)
+#define GL_FUNC_EXT(ExtFunctionName, FunctionName)                    \
+  else if (strcmp(name, #ExtFunctionName) == 0) {                     \
+    return reinterpret_cast<void*>(eglGetProcAddress(#FunctionName)); \
+  }
+  GL_FUNC_EXT(glMultiDrawArraysIndirectEXT, glMultiDrawArraysIndirect)
+  GL_FUNC_EXT(glMultiDrawElementsIndirectEXT, glMultiDrawElementsIndirect)
+#undef GL_FUNC_EXT
 #undef GL_FUNC
 
   FT_LOG(Warn) << "Could not resolve: " << name;


### PR DESCRIPTION
In Tizen 10.0, Skia gl context init fails because glMultiDrawArraysIndirectEXT, glMultiDrawElementsIndirectEXT are not found.

in engine/src/flutter/third_party/skia/src/gpu/ganesh/gl/GrGLInterfaceAutogen.cpp
```
370     if ((GR_IS_GR_GL(fStandard) && (
371           (glVer >= GR_GL_VER(4,3)) ||
372           fExtensions.has("GL_ARB_multi_draw_indirect"))) ||
373        (GR_IS_GR_GL_ES(fStandard) && (
374           fExtensions.has("GL_EXT_multi_draw_indirect")))) {
375         if (!fFunctions.fMultiDrawArraysIndirect ||
376             !fFunctions.fMultiDrawElementsIndirect) {
377             RETURN_FALSE_INTERFACE;
378         }
379     }
```