### PR TITLE
[ci] Add vulkan-loader to the docker image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,11 @@ jobs:
           wget -q ${REPO_URL}/${BUILD_ID}/images/standard/${IMAGE}/${BUILD_ID}_${IMAGE}.tar.gz
           tar -zxf ${BUILD_ID}_${IMAGE}.tar.gz
           mkdir rootfs
+
+          # TODO(jsuya) : vulkan-loader is not included in the image binary.
+          wget -q ${REPO_URL}/${BUILD_ID}/repos/standard/packages/armv7l/vulkan-loader-1.3.208-0.armv7l.rpm
+          rpm2cpio vulkan-loader-1.3.208-0.armv7l.rpm | cpio -idmv -D rootfs
+
           sudo mount rootfs.img rootfs
           sudo tar -cC rootfs . | docker import - ghcr.io/${{ github.repository_owner }}/${IMAGE}
           sudo umount rootfs


### PR DESCRIPTION
vulkan-loader is not included in the image binary. so add it manually.

https://download.tizen.org/releases/milestone/TIZEN/Tizen/Tizen-Unified/tizen-unified_20221017.061100/images/standard/tizen-headed-armv7l/tizen-unified_20221017.061100_tizen-headed-armv7l.packages