### PR TITLE
Fix static analysis issue

### DIFF
--- a/flutter/shell/platform/tizen/channels/platform_channel.cc
+++ b/flutter/shell/platform/tizen/channels/platform_channel.cc
@@ -105,16 +105,29 @@ void PlatformChannel::HandleMethodCall(
     SystemNavigatorPop();
     result->Success();
   } else if (method == kPlaySoundMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     PlaySystemSound(arguments[0].GetString());
     result->Success();
   } else if (method == kHapticFeedbackVibrateMethod) {
     std::string type;
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     if (arguments->IsString()) {
       type = arguments[0].GetString();
     }
     HapticFeedbackVibrate(type);
     result->Success();
   } else if (method == kGetClipboardDataMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
+
     // https://api.flutter.dev/flutter/services/Clipboard/kTextPlain-constant.html
     // The API only supports the plain text format.
     if (strcmp(arguments[0].GetString(), kTextPlainFormat) != 0) {
@@ -144,6 +157,10 @@ void PlatformChannel::HandleMethodCall(
       delete result_ptr;
     };
   } else if (method == kSetClipboardDataMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     const rapidjson::Value& document = *arguments;
     auto iter = document.FindMember(kTextKey);
     if (iter == document.MemberEnd()) {
@@ -160,6 +177,10 @@ void PlatformChannel::HandleMethodCall(
                        rapidjson::Value(ClipboardHasStrings()), allocator);
     result->Success(document);
   } else if (method == kExitApplicationMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     rapidjson::Value::ConstMemberIterator iter =
         arguments->FindMember(kExitTypeKey);
     if (iter == arguments->MemberEnd()) {
@@ -190,6 +211,10 @@ void PlatformChannel::HandleMethodCall(
     RestoreSystemUiOverlays();
     result->Success();
   } else if (method == kSetEnabledSystemUiOverlaysMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     const rapidjson::Document& list = arguments[0];
     std::vector<std::string> overlays;
     for (auto iter = list.Begin(); iter != list.End(); ++iter) {
@@ -198,6 +223,10 @@ void PlatformChannel::HandleMethodCall(
     SetEnabledSystemUiOverlays(overlays);
     result->Success();
   } else if (method == kSetPreferredOrientationsMethod) {
+    if (!arguments) {
+      result->Error("Invalid arguments");
+      return;
+    }
     const rapidjson::Document& list = arguments[0];
     std::vector<std::string> orientations;
     for (auto iter = list.Begin(); iter != list.End(); ++iter) {

--- a/flutter/shell/platform/tizen/tizen_renderer_egl.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_egl.cc
@@ -200,6 +200,10 @@ bool TizenRendererEgl::ChooseEGLConfiguration() {
   }
 
   EGLConfig* configs = (EGLConfig*)calloc(config_size, sizeof(EGLConfig));
+  if (!configs) {
+    FT_LOG(Error) << "Failed to allocate memory for EGL configurations.";
+    return false;
+  }
   EGLint num_config;
   if (enable_impeller_) {
     EGLint impeller_config_attribs[] = {


### PR DESCRIPTION
This is a commit to handle the following Warning Messages found by our SVACe (static analysis tool).
1. Pointer, returned from function 'calloc' at tizen_renderer_egl.cc:202, may be NULL and is dereferenced at tizen_renderer_egl.cc 253.
2. Return value of a function 'arguments' is dereferenced at platform_channel.cc:203 without checking for NULL, but it is usually checked for this function.