### PR TITLE
Supports activate/raise/lower window

### DIFF
--- a/flutter/shell/platform/tizen/channels/window_channel.cc
+++ b/flutter/shell/platform/tizen/channels/window_channel.cc
@@ -7,6 +7,8 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/tizen/channels/encodable_value_holder.h"
 #include "flutter/shell/platform/tizen/logger.h"
+#include "flutter/shell/platform/tizen/tizen_window.h"
+#include "flutter/shell/platform/tizen/tizen_window_ecore_wl2.h"
 
 namespace flutter {
 
@@ -72,6 +74,15 @@ void WindowChannel::HandleMethodCall(
     result->Success(EncodableValue(map));
   } else if (method_name == "getRotation") {
     result->Success(EncodableValue(window_->GetRotation()));
+  } else if (method_name == "activateWindow") {
+    window_->activateWindow();
+    result->Success();
+  } else if (method_name == "raiseWindow") {
+    window_->raiseWindow();
+    result->Success();
+  } else if (method_name == "lowerWindow") {
+    window_->lowerWindow();
+    result->Success();
   } else {
     result->NotImplemented();
   }

--- a/flutter/shell/platform/tizen/tizen_window.h
+++ b/flutter/shell/platform/tizen/tizen_window.h
@@ -30,6 +30,12 @@ class TizenWindow : public TizenViewBase {
 
   virtual void BindKeys(const std::vector<std::string>& keys) = 0;
 
+  virtual void activateWindow() = 0;
+
+  virtual void raiseWindow() = 0;
+
+  virtual void lowerWindow() = 0;
+
  protected:
   explicit TizenWindow(TizenGeometry geometry,
                        bool transparent,

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.cc
@@ -848,4 +848,16 @@ void TizenWindowEcoreWl2::PrepareInputMethod() {
       [this](std::string str) { view_delegate_->OnCommit(str); });
 }
 
+void TizenWindowEcoreWl2::activateWindow() {
+  ecore_wl2_window_activate(ecore_wl2_window_);
+}
+
+void TizenWindowEcoreWl2::raiseWindow() {
+  ecore_wl2_window_raise(ecore_wl2_window_);
+}
+
+void TizenWindowEcoreWl2::lowerWindow() {
+  ecore_wl2_window_lower(ecore_wl2_window_);
+}
+
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
+++ b/flutter/shell/platform/tizen/tizen_window_ecore_wl2.h
@@ -57,6 +57,12 @@ class TizenWindowEcoreWl2 : public TizenWindow {
 
   void UpdateFlutterCursor(const std::string& kind) override;
 
+  void activateWindow() override;
+
+  void raiseWindow() override;
+
+  void lowerWindow() override;
+
  private:
   bool CreateWindow(void* window_handle);
 

--- a/flutter/shell/platform/tizen/tizen_window_elementary.cc
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.cc
@@ -425,4 +425,16 @@ void TizenWindowElementary::PrepareInputMethod() {
       [this](std::string str) { view_delegate_->OnCommit(str); });
 }
 
+void TizenWindowElementary::activateWindow() {
+  elm_win_activate(elm_win_);
+}
+
+void TizenWindowElementary::raiseWindow() {
+  elm_win_raise(elm_win_);
+}
+
+void TizenWindowElementary::lowerWindow() {
+  elm_win_lower(elm_win_);
+}
+
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_window_elementary.h
+++ b/flutter/shell/platform/tizen/tizen_window_elementary.h
@@ -54,6 +54,12 @@ class TizenWindowElementary : public TizenWindow {
 
   void UpdateFlutterCursor(const std::string& kind) override;
 
+  void activateWindow() override;
+
+  void raiseWindow() override;
+
+  void lowerWindow() override;
+
  private:
   bool CreateWindow();
 


### PR DESCRIPTION
Add a method to control windows using the ‘tizen/internal/window’ method channel.
The *_window_activate() function is known to prevent windows from showing without rendering, unlike *_window_raise.
However, since it causes a delay before the window appears, raise is faster unless a re-render is required.