### PR TITLE
Fix Exit, Back key handling

### DIFF
--- a/flutter/shell/platform/tizen/channels/keyboard_channel.cc
+++ b/flutter/shell/platform/tizen/channels/keyboard_channel.cc
@@ -244,7 +244,7 @@ void KeyboardChannel::SendEmbedderEvent(const char* key,
           .synthesized = false,
       };
       send_event_(empty_event, nullptr, nullptr);
-      ResolvePendingEvent(sequence_id, true);
+      ResolvePendingEvent(sequence_id, false);
       return;
     } else {
       type = kFlutterKeyEventTypeUp;


### PR DESCRIPTION
- Fixes an issue where inputs such as the back key or exit key would not be processed properly when the last_logical_record parameter is not present. Since the `handled` parameter is used for the back key and exit key, this change is expected to have no impact on other key inputs.

https://github.com/flutter-tizen/flutter-tizen/issues/676#issuecomment-3541226334