### PR TITLE
Prevent use-after-free of eina_thread_queue in TizenVsyncWaiter

### DIFF
--- a/flutter/shell/platform/tizen/tizen_vsync_waiter.cc
+++ b/flutter/shell/platform/tizen/tizen_vsync_waiter.cc
@@ -102,6 +102,7 @@ void TizenVsyncWaiter::RunVblankLoop(void* data, Ecore_Thread* thread) {
 
   if (vblank_thread_queue) {
     eina_thread_queue_free(vblank_thread_queue);
+    self->vblank_thread_queue_ = nullptr;
   }
 }
 


### PR DESCRIPTION
Set nullptr to prevent it from being used by other callbacks after vblank_thread_queue_ is freed.

https://github.com/flutter-tizen/embedder/issues/135