### PR TITLE
Skip adding empty identifier attribute to accessibility tree

### DIFF
--- a/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/flutter/shell/platform/common/accessibility_bridge.cc
@@ -528,8 +528,10 @@ void AccessibilityBridge::SetStringListAttributesFromFlutterUpdate(
 void AccessibilityBridge::SetIdentifierFromFlutterUpdate(
     ui::AXNodeData& node_data,
     const SemanticsNode& node) {
-  node_data.AddStringAttribute(ax::mojom::StringAttribute::kIdentifier,
-                               node.identifier);
+  if (!node.identifier.empty()) {
+    node_data.AddStringAttribute(ax::mojom::StringAttribute::kIdentifier,
+                                 node.identifier);
+  }
 }
 
 void AccessibilityBridge::SetNameFromFlutterUpdate(ui::AXNodeData& node_data,


### PR DESCRIPTION
SetIdentifierFromFlutterUpdate unconditionally adds kIdentifier string attribute to every semantics node, even when the identifier is empty. This adds unnecessary overhead to the accessibility tree and may cause unexpected behavior in screen readers.

issue: https://github.com/flutter-tizen/embedder/issues/165