### PR TITLE
Send IME geometry alongside state

### DIFF
--- a/flutter/shell/platform/tizen/channels/input_panel_channel.cc
+++ b/flutter/shell/platform/tizen/channels/input_panel_channel.cc
@@ -54,8 +54,13 @@ void InputPanelChannel::SendInputPanelStateEvent(const std::string& state) {
     return;
   }
 
+  InputPanelGeometry geometry = imf_context_->GetInputPanelGeometry();
   EncodableMap event;
   event[EncodableValue("state")] = EncodableValue(state);
+  event[EncodableValue("x")] = EncodableValue(geometry.x);
+  event[EncodableValue("y")] = EncodableValue(geometry.y);
+  event[EncodableValue("width")] = EncodableValue(geometry.w);
+  event[EncodableValue("height")] = EncodableValue(geometry.h);
   event_sink_->Success(EncodableValue(event));
 }
 


### PR DESCRIPTION
The Tizen input panel channel only emitted the state string (show / hide / will_show), so app side had no way to learn the geometry. 
The geometry is already available via TizenInputMethodContext::GetInputPanelGeometry, so include x/y/width/ height in every state event.