### PR TITLE
Use exact trig values for rotation transform in OnRotate

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen_view.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_view.cc
@@ -125,24 +125,30 @@ void FlutterTizenView::OnRotate(int32_t degree) {
   int32_t width = geometry.width;
   int32_t height = geometry.height;
   if (dynamic_cast<TizenRendererEgl*>(engine_->renderer())) {
-    rotation_degree_ = degree;
-    // Compute renderer transformation based on the angle of rotation.
-    double rad = (360 - rotation_degree_) * M_PI / 180;
-    double trans_x = 0.0, trans_y = 0.0;
-    if (rotation_degree_ == 90) {
-      trans_y = height;
-    } else if (rotation_degree_ == 180) {
-      trans_x = width;
-      trans_y = height;
-    } else if (rotation_degree_ == 270) {
-      trans_x = width;
+    rotation_degree_ = (degree % 360 + 360) % 360;
+    const double w = width;
+    const double h = height;
+    switch (rotation_degree_) {
+      case 0:
+        flutter_transformation_ = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+        break;
+      case 90:
+        flutter_transformation_ = {0.0, 1.0, 0.0, -1.0, 0.0, h, 0.0, 0.0, 1.0};
+        break;
+      case 180:
+        flutter_transformation_ = {-1.0, 0.0, w, 0.0, -1.0, h, 0.0, 0.0, 1.0};
+        break;
+      case 270:
+        flutter_transformation_ = {0.0, -1.0, w, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0};
+        break;
+      default: {
+        double rad = (360 - rotation_degree_) * M_PI / 180;
+        flutter_transformation_ = {
+            cos(rad), -sin(rad), 0.0, sin(rad), cos(rad), 0.0, 0.0, 0.0, 1.0,
+        };
+        break;
+      }
     }
-
-    flutter_transformation_ = {
-        cos(rad), -sin(rad), trans_x,  // x
-        sin(rad), cos(rad),  trans_y,  // y
-        0.0,      0.0,       1.0       // perspective
-    };
 
     if (rotation_degree_ == 90 || rotation_degree_ == 270) {
       std::swap(width, height);


### PR DESCRIPTION
cos/sin of pi multiples leaves ~1e-16 dust on entries that mathematically equal 0 or +-1. The dust scales y=1080 to 1079.99999... and shifts the bottom/right edge by 1 px in rasterizer paths that floor the transformed vertex. SendInitialGeometry calls OnRotate(degree=0) at startup, so non-rotating Skia + GLES apps were also affected and the player overlay (avplay videohole) appeared 1-2 px below adjacent Flutter widgets at the screen's bottom edge. Impeller's GLES backend short-circuits near-identity transforms and did not exhibit the shift.

Use exact 0 / +-1 / width / height entries for the cardinal angles (0, 90, 180, 270), and keep the cos/sin computation in the default branch so arbitrary rotation degrees remain supported.


https://github.com/flutter-tizen/flutter-tizen/issues/764