### PR TITLE
Fix event loop re-entrancy issue on merged thread policy

### DIFF
--- a/flutter/shell/platform/tizen/tizen_event_loop.cc
+++ b/flutter/shell/platform/tizen/tizen_event_loop.cc
@@ -104,7 +104,6 @@ void TizenPlatformEventLoop::OnTaskExpired() {
   {
     std::lock_guard<std::mutex> lock(expired_tasks_mutex_);
     local_expired_tasks = std::move(expired_tasks_);
-    expired_tasks_.clear();
   }
 
   for (const Task& task : local_expired_tasks) {

--- a/flutter/shell/platform/tizen/tizen_event_loop.cc
+++ b/flutter/shell/platform/tizen/tizen_event_loop.cc
@@ -100,10 +100,15 @@ TizenPlatformEventLoop::TizenPlatformEventLoop(
 TizenPlatformEventLoop::~TizenPlatformEventLoop() {}
 
 void TizenPlatformEventLoop::OnTaskExpired() {
-  for (const Task& task : expired_tasks_) {
+  std::vector<Task> local_expired_tasks;
+  {
+    std::lock_guard<std::mutex> lock(expired_tasks_mutex_);
+    local_expired_tasks = std::move(expired_tasks_);
+  }
+
+  for (const Task& task : local_expired_tasks) {
     on_task_expired_(&task.task);
   }
-  expired_tasks_.clear();
 }
 
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_event_loop.cc
+++ b/flutter/shell/platform/tizen/tizen_event_loop.cc
@@ -104,6 +104,7 @@ void TizenPlatformEventLoop::OnTaskExpired() {
   {
     std::lock_guard<std::mutex> lock(expired_tasks_mutex_);
     local_expired_tasks = std::move(expired_tasks_);
+    expired_tasks_.clear();
   }
 
   for (const Task& task : local_expired_tasks) {


### PR DESCRIPTION
This PR resolves an event loop re-entrancy issue under the merged UI/Platform thread policy by using a local variable to prevent memory corruption and task dispatch failures.