### PR TITLE
Change the log level from Error to Debug

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -471,7 +471,7 @@ void FlutterTizenEngine::SetSemanticsEnabled(bool enabled) {
 void FlutterTizenEngine::OnUpdateSemantics(
     const FlutterSemanticsUpdate2* update) {
   if (!accessibility_bridge_) {
-    FT_LOG(Error) << "The accessibility bridge must be initialized.";
+    FT_LOG(Debug) << "The accessibility bridge must be initialized.";
     return;
   }
 


### PR DESCRIPTION
During integration tests (flutter-tizen drive), the test framework automatically enables and sends semantics updates. However, since the default accessibility service is disabled on the device, the accessibility bridge becomes null. This causes unnecessary error logs that clutter the output and make log analysis difficult. To resolve this, this PR changes the log level to Debug, aligning the behavior with other Flutter platform embedders (such as Windows and Linux) that handle this case silently.