### PR TITLE
Minor refactor for vulkan renderer

### DIFF
--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -42,6 +42,12 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
     return false;
   }
 
+  if (pixel_buffer->width == 0 || pixel_buffer->height == 0) {
+    FT_LOG(Error) << "Invalid pixel buffer dimensions: " << pixel_buffer->width
+                  << "x" << pixel_buffer->height;
+    return false;
+  }
+
   if (!CreateOrUpdateImage(pixel_buffer->width, pixel_buffer->height)) {
     FT_LOG(Error) << "Fail to create image";
     ReleaseImage();

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -49,7 +49,8 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
   }
 
   VkDeviceSize required_staging_size =
-      pixel_buffer->width * pixel_buffer->height * 4;
+      static_cast<VkDeviceSize>(pixel_buffer->width) *
+      static_cast<VkDeviceSize>(pixel_buffer->height) * 4;
   if (!CreateOrUpdateBuffer(required_staging_size)) {
     FT_LOG(Error) << "Fail to create buffer";
     ReleaseBuffer();

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -244,7 +244,7 @@ bool ExternalTexturePixelVulkan::AllocateMemory(
   return true;
 }
 
-VkDevice ExternalTexturePixelVulkan::GetDevice() {
+VkDevice ExternalTexturePixelVulkan::GetDevice() const {
   return static_cast<VkDevice>(vulkan_renderer_->GetDeviceHandle());
 }
 

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -60,7 +60,10 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
   width_ = pixel_buffer->width;
   height_ = pixel_buffer->height;
 
-  CopyBufferToImage(pixel_buffer->buffer, required_staging_size);
+  if (!CopyBufferToImage(pixel_buffer->buffer, required_staging_size)) {
+    FT_LOG(Error) << "Failed to copy buffer to image";
+    return false;
+  }
 
   FlutterVulkanTexture* vulkan_texture =
       static_cast<FlutterVulkanTexture*>(flutter_texture);
@@ -179,18 +182,23 @@ void ExternalTexturePixelVulkan::ReleaseBuffer() {
   staging_buffer_size_ = 0;
 }
 
-void ExternalTexturePixelVulkan::CopyBufferToImage(const uint8_t* src_buffer,
+bool ExternalTexturePixelVulkan::CopyBufferToImage(const uint8_t* src_buffer,
                                                    VkDeviceSize size) {
   void* data;
   VkResult result =
       vkMapMemory(GetDevice(), staging_buffer_memory_, 0, size, 0, &data);
   if (result != VK_SUCCESS) {
     FT_LOG(Error) << "Failed to map staging buffer memory";
-    return;
+    return false;
   }
   memcpy(data, src_buffer, static_cast<size_t>(size));
   vkUnmapMemory(GetDevice(), staging_buffer_memory_);
+
   VkCommandBuffer command_buffer = vulkan_renderer_->BeginSingleTimeCommands();
+  if (command_buffer == VK_NULL_HANDLE) {
+    FT_LOG(Error) << "Failed to begin single time commands";
+    return false;
+  }
 
   VkBufferImageCopy region{};
   region.bufferOffset = 0;
@@ -208,6 +216,7 @@ void ExternalTexturePixelVulkan::CopyBufferToImage(const uint8_t* src_buffer,
                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
   vulkan_renderer_->EndSingleTimeCommands(command_buffer);
+  return true;
 }
 
 void ExternalTexturePixelVulkan::ReleaseImage() {

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -237,7 +237,7 @@ bool ExternalTexturePixelVulkan::AllocateMemory(
     VkMemoryPropertyFlags properties) {
   uint32_t memory_type_index;
   if (!vulkan_renderer_->FindMemoryType(memory_requirements.memoryTypeBits,
-                                        properties, memory_type_index)) {
+                                        properties, &memory_type_index)) {
     FT_LOG(Error) << "Fail to find memory type";
     return false;
   }

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -37,6 +37,11 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
     return false;
   }
 
+  if (!pixel_buffer->buffer) {
+    FT_LOG(Error) << "pixel_buffer->buffer is nullptr";
+    return false;
+  }
+
   if (!CreateOrUpdateImage(pixel_buffer->width, pixel_buffer->height)) {
     FT_LOG(Error) << "Fail to create image";
     ReleaseImage();
@@ -127,27 +132,6 @@ bool ExternalTexturePixelVulkan::CreateImage(size_t width, size_t height) {
   return true;
 }
 
-bool ExternalTexturePixelVulkan::FindMemoryType(
-    uint32_t type_filter,
-    VkMemoryPropertyFlags properties,
-    uint32_t& index_out) {
-  VkPhysicalDeviceMemoryProperties memory_properties;
-  vkGetPhysicalDeviceMemoryProperties(
-      static_cast<VkPhysicalDevice>(
-          vulkan_renderer_->GetPhysicalDeviceHandle()),
-      &memory_properties);
-
-  for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++) {
-    if ((type_filter & (1 << i)) &&
-        (memory_properties.memoryTypes[i].propertyFlags & properties) ==
-            properties) {
-      index_out = i;
-      return true;
-    }
-  }
-  return false;
-}
-
 bool ExternalTexturePixelVulkan::CreateBuffer(VkDeviceSize required_size) {
   VkBufferCreateInfo buffer_info{};
   buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -197,7 +181,12 @@ void ExternalTexturePixelVulkan::ReleaseBuffer() {
 void ExternalTexturePixelVulkan::CopyBufferToImage(const uint8_t* src_buffer,
                                                    VkDeviceSize size) {
   void* data;
-  vkMapMemory(GetDevice(), staging_buffer_memory_, 0, size, 0, &data);
+  VkResult result =
+      vkMapMemory(GetDevice(), staging_buffer_memory_, 0, size, 0, &data);
+  if (result != VK_SUCCESS) {
+    FT_LOG(Error) << "Failed to map staging buffer memory";
+    return;
+  }
   memcpy(data, src_buffer, static_cast<size_t>(size));
   vkUnmapMemory(GetDevice(), staging_buffer_memory_);
   VkCommandBuffer command_buffer = vulkan_renderer_->BeginSingleTimeCommands();
@@ -237,8 +226,8 @@ bool ExternalTexturePixelVulkan::AllocateMemory(
     VkDeviceMemory& memory,
     VkMemoryPropertyFlags properties) {
   uint32_t memory_type_index;
-  if (!FindMemoryType(memory_requirements.memoryTypeBits, properties,
-                      memory_type_index)) {
+  if (!vulkan_renderer_->FindMemoryType(memory_requirements.memoryTypeBits,
+                                        properties, memory_type_index)) {
     FT_LOG(Error) << "Fail to find memory type";
     return false;
   }

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
@@ -32,7 +32,7 @@ class ExternalTexturePixelVulkan : public ExternalVulkanTexture {
   bool CreateImage(size_t width, size_t height);
   bool CreateOrUpdateBuffer(VkDeviceSize required_size);
   bool CreateOrUpdateImage(size_t width, size_t height);
-  void CopyBufferToImage(const uint8_t* src_buffer, VkDeviceSize size);
+  bool CopyBufferToImage(const uint8_t* src_buffer, VkDeviceSize size);
   VkDevice GetDevice() const;
   void ReleaseBuffer();
   void ReleaseImage();

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
@@ -36,9 +36,6 @@ class ExternalTexturePixelVulkan : public ExternalVulkanTexture {
   VkDevice GetDevice();
   void ReleaseBuffer();
   void ReleaseImage();
-  bool FindMemoryType(uint32_t typeFilter,
-                      VkMemoryPropertyFlags properties,
-                      uint32_t& index_out);
   FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
   size_t width_ = 0;
   size_t height_ = 0;

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
@@ -33,7 +33,7 @@ class ExternalTexturePixelVulkan : public ExternalVulkanTexture {
   bool CreateOrUpdateBuffer(VkDeviceSize required_size);
   bool CreateOrUpdateImage(size_t width, size_t height);
   void CopyBufferToImage(const uint8_t* src_buffer, VkDeviceSize size);
-  VkDevice GetDevice();
+  VkDevice GetDevice() const;
   void ReleaseBuffer();
   void ReleaseImage();
   FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan.cc
@@ -47,6 +47,7 @@ bool ExternalTextureSurfaceVulkan::CreateBuffer(
   }
   if (!vulkan_buffer_->AllocateAndBindMemory(tbm_surface)) {
     FT_LOG(Error) << "Fail to allocate memory";
+    vulkan_buffer_->ReleaseImage();
     return false;
   }
 

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
@@ -31,7 +31,7 @@ VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(tbm_format& format) {
   }
 }
 
-VkDevice ExternalTextureSurfaceVulkanBuffer::GetDevice() {
+VkDevice ExternalTextureSurfaceVulkanBuffer::GetDevice() const {
   return static_cast<VkDevice>(vulkan_renderer_->GetDeviceHandle());
 }
 

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
@@ -31,27 +31,6 @@ VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(tbm_format& format) {
   }
 }
 
-bool ExternalTextureSurfaceVulkanBuffer::FindMemoryType(
-    uint32_t type_filter,
-    VkMemoryPropertyFlags properties,
-    uint32_t& index_out) {
-  VkPhysicalDeviceMemoryProperties memory_properties;
-  vkGetPhysicalDeviceMemoryProperties(
-      static_cast<VkPhysicalDevice>(
-          vulkan_renderer_->GetPhysicalDeviceHandle()),
-      &memory_properties);
-
-  for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++) {
-    if ((type_filter & (1 << i)) &&
-        (memory_properties.memoryTypes[i].propertyFlags & properties) ==
-            properties) {
-      index_out = i;
-      return true;
-    }
-  }
-  return false;
-}
-
 VkDevice ExternalTextureSurfaceVulkanBuffer::GetDevice() {
   return static_cast<VkDevice>(vulkan_renderer_->GetDeviceHandle());
 }

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
@@ -32,9 +32,6 @@ class ExternalTextureSurfaceVulkanBuffer {
  protected:
   VkFormat ConvertFormat(tbm_format& format);
   VkDevice GetDevice();
-  bool FindMemoryType(uint32_t memory_type_bits_requirement,
-                      VkMemoryPropertyFlags required_properties,
-                      uint32_t& index_out);
 
  private:
   TizenRendererVulkan* vulkan_renderer_ = nullptr;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
@@ -31,7 +31,7 @@ class ExternalTextureSurfaceVulkanBuffer {
 
  protected:
   VkFormat ConvertFormat(tbm_format& format);
-  VkDevice GetDevice();
+  VkDevice GetDevice() const;
 
  private:
   TizenRendererVulkan* vulkan_renderer_ = nullptr;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -32,7 +32,11 @@ VkDeviceMemory ExternalTextureSurfaceVulkanBufferDma::GetMemory() {
 bool ExternalTextureSurfaceVulkanBufferDma::CreateImage(
     tbm_surface_h tbm_surface) {
   tbm_surface_info_s tbm_surface_info;
-  tbm_surface_get_info(tbm_surface, &tbm_surface_info);
+  if (tbm_surface_get_info(tbm_surface, &tbm_surface_info) !=
+      TBM_SURFACE_ERROR_NONE) {
+    FT_LOG(Error) << "Fail to get tbm_surface info";
+    return false;
+  }
   texture_format_ = ConvertFormat(tbm_surface_info.format);
 
   VkExternalMemoryImageCreateInfoKHR external_image_create_info = {};

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -142,6 +142,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
   if (vkBindImageMemory(GetDevice(), texture_image_, texture_device_memory_,
                         0u) != VK_SUCCESS) {
     FT_LOG(Error) << "Fail to bind image memory";
+    close(bo_fd);
     return false;
   }
   return true;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -113,7 +113,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
   int bo_fd = tbm_bo_export_fd(bo);
   int bo_size = tbm_bo_size(bo);
 
-  uint32_t memory_type_index = -1;
+  uint32_t memory_type_index = 0;
   if (!GetFdMemoryTypeIndex(bo_fd, memory_type_index)) {
     FT_LOG(Error) << "Fail to get memory type index";
     return false;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h"
+#include <unistd.h>
 #include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
@@ -129,6 +130,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
   if (vkAllocateMemory(GetDevice(), &alloc_info, nullptr,
                        &texture_device_memory_) != VK_SUCCESS) {
     FT_LOG(Error) << "Fail to allocate memory";
+    close(bo_fd);
     return false;
   }
 
@@ -137,7 +139,6 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
     FT_LOG(Error) << "Fail to bind image memory";
     return false;
   }
-  close(bo_fd);
   return true;
 }
 

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -116,6 +116,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
   uint32_t memory_type_index = 0;
   if (!GetFdMemoryTypeIndex(bo_fd, memory_type_index)) {
     FT_LOG(Error) << "Fail to get memory type index";
+    close(bo_fd);
     return false;
   }
 

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -1022,4 +1022,21 @@ void TizenRendererVulkan::EndSingleTimeCommands(VkCommandBuffer commandBuffer) {
                        &commandBuffer);
 }
 
+bool TizenRendererVulkan::FindMemoryType(uint32_t type_filter,
+                                         VkMemoryPropertyFlags properties,
+                                         uint32_t& index_out) {
+  VkPhysicalDeviceMemoryProperties memory_properties;
+  vkGetPhysicalDeviceMemoryProperties(physical_device_, &memory_properties);
+
+  for (uint32_t i = 0; i < memory_properties.memoryTypeCount; i++) {
+    if ((type_filter & (1 << i)) &&
+        (memory_properties.memoryTypes[i].propertyFlags & properties) ==
+            properties) {
+      index_out = i;
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace flutter

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -1023,7 +1023,7 @@ void TizenRendererVulkan::EndSingleTimeCommands(VkCommandBuffer commandBuffer) {
 
 bool TizenRendererVulkan::FindMemoryType(uint32_t type_filter,
                                          VkMemoryPropertyFlags properties,
-                                         uint32_t& index_out) {
+                                         uint32_t* index_out) {
   VkPhysicalDeviceMemoryProperties memory_properties;
   vkGetPhysicalDeviceMemoryProperties(physical_device_, &memory_properties);
 
@@ -1031,7 +1031,7 @@ bool TizenRendererVulkan::FindMemoryType(uint32_t type_filter,
     if ((type_filter & (1 << i)) &&
         (memory_properties.memoryTypes[i].propertyFlags & properties) ==
             properties) {
-      index_out = i;
+      *index_out = i;
       return true;
     }
   }

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -1024,6 +1024,9 @@ void TizenRendererVulkan::EndSingleTimeCommands(VkCommandBuffer commandBuffer) {
 bool TizenRendererVulkan::FindMemoryType(uint32_t type_filter,
                                          VkMemoryPropertyFlags properties,
                                          uint32_t* index_out) {
+  if (!index_out) {
+    return false;
+  }
   VkPhysicalDeviceMemoryProperties memory_properties;
   vkGetPhysicalDeviceMemoryProperties(physical_device_, &memory_properties);
 

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -102,7 +102,7 @@ bool TizenRendererVulkan::InitVulkan(TizenViewBase* view) {
 }
 
 void TizenRendererVulkan::Cleanup() {
-  if (logical_device_) {
+  if (logical_device_ != VK_NULL_HANDLE) {
     // Ensure all GPU work is complete before destroying anything.
     vkDeviceWaitIdle(logical_device_);
 
@@ -749,7 +749,6 @@ bool TizenRendererVulkan::InitializeSwapchain() {
     FT_LOG(Error) << "Could not get swap chain images count";
     return false;
   }
-  // swapchain_images_.reserve(image_count);
   swapchain_images_.resize(image_count);
   if (vkGetSwapchainImagesKHR(logical_device_, swapchain_, &image_count,
                               swapchain_images_.data()) != VK_SUCCESS) {

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
@@ -51,6 +51,9 @@ class TizenRendererVulkan : public TizenRenderer {
   bool Present(const FlutterVulkanImage* image);
   VkCommandBuffer BeginSingleTimeCommands();
   void EndSingleTimeCommands(VkCommandBuffer commandBuffer);
+  bool FindMemoryType(uint32_t type_filter,
+                      VkMemoryPropertyFlags properties,
+                      uint32_t& index_out);
 
  private:
   bool CreateCommandPool();

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
@@ -53,7 +53,7 @@ class TizenRendererVulkan : public TizenRenderer {
   void EndSingleTimeCommands(VkCommandBuffer commandBuffer);
   bool FindMemoryType(uint32_t type_filter,
                       VkMemoryPropertyFlags properties,
-                      uint32_t& index_out);
+                      uint32_t* index_out);
 
  private:
   bool CreateCommandPool();


### PR DESCRIPTION
Main changes:
1. Move FindMemoryType method to vulkan renderer.
2. Make GetDevice method to const.
3. Cast to VkDeviceSize before multiplication.
4. Add missing return value check for tbm_surface_get_info
5. Initialize memory_type_index to 0 instead of -1
6. Fix Vulkan texture error handling issues
7. Change FindMemoryType output parameter from reference to pointer
8. Add null check in FindMemoryType to prevent null pointer dereference
9. Fix file descriptor leak in ExternalTextureSurfaceVulkanBufferDma
10. Add pixel buffer dimension validation in ExternalTexturePixelVulkan