### PR TITLE
Minor refactor for vulkan renderer(The second)

### DIFF
--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -70,6 +70,8 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
     FT_LOG(Error) << "Failed to copy buffer to image";
     ReleaseBuffer();
     ReleaseImage();
+    width_ = 0;
+    height_ = 0;
     return false;
   }
 

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -205,6 +205,9 @@ bool ExternalTexturePixelVulkan::CopyBufferToImage(const uint8_t* src_buffer,
   VkCommandBuffer command_buffer = vulkan_renderer_->BeginSingleTimeCommands();
   if (command_buffer == VK_NULL_HANDLE) {
     FT_LOG(Error) << "Failed to begin single time commands";
+    // Note: staging buffer data was copied but won't be transferred to image
+    // due to command buffer allocation failure. The memory is properly
+    // unmapped.
     return false;
   }
 

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -68,6 +68,8 @@ bool ExternalTexturePixelVulkan::PopulateVulkanTexture(
 
   if (!CopyBufferToImage(pixel_buffer->buffer, required_staging_size)) {
     FT_LOG(Error) << "Failed to copy buffer to image";
+    ReleaseBuffer();
+    ReleaseImage();
     return false;
   }
 

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -246,6 +246,10 @@ bool ExternalTexturePixelVulkan::AllocateMemory(
     const VkMemoryRequirements& memory_requirements,
     VkDeviceMemory* memory,
     VkMemoryPropertyFlags properties) {
+  if (!memory) {
+    FT_LOG(Error) << "memory pointer is nullptr";
+    return false;
+  }
   uint32_t memory_type_index;
   if (!vulkan_renderer_->FindMemoryType(memory_requirements.memoryTypeBits,
                                         properties, &memory_type_index)) {

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.cc
@@ -129,7 +129,7 @@ bool ExternalTexturePixelVulkan::CreateImage(size_t width, size_t height) {
   VkMemoryRequirements memory_requirements;
   vkGetImageMemoryRequirements(GetDevice(), image_, &memory_requirements);
 
-  if (!AllocateMemory(memory_requirements, image_memory_,
+  if (!AllocateMemory(memory_requirements, &image_memory_,
                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
     FT_LOG(Error) << "Fail to allocate image memory";
     return false;
@@ -159,7 +159,7 @@ bool ExternalTexturePixelVulkan::CreateBuffer(VkDeviceSize required_size) {
   vkGetBufferMemoryRequirements(GetDevice(), staging_buffer_,
                                 &memory_requirements);
 
-  if (!AllocateMemory(memory_requirements, staging_buffer_memory_,
+  if (!AllocateMemory(memory_requirements, &staging_buffer_memory_,
                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
                           VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
     FT_LOG(Error) << "Fail to allocate buffer memory";
@@ -239,7 +239,7 @@ void ExternalTexturePixelVulkan::ReleaseImage() {
 
 bool ExternalTexturePixelVulkan::AllocateMemory(
     const VkMemoryRequirements& memory_requirements,
-    VkDeviceMemory& memory,
+    VkDeviceMemory* memory,
     VkMemoryPropertyFlags properties) {
   uint32_t memory_type_index;
   if (!vulkan_renderer_->FindMemoryType(memory_requirements.memoryTypeBits,
@@ -252,7 +252,7 @@ bool ExternalTexturePixelVulkan::AllocateMemory(
   alloc_info.allocationSize = memory_requirements.size;
   alloc_info.memoryTypeIndex = memory_type_index;
 
-  if (vkAllocateMemory(GetDevice(), &alloc_info, nullptr, &memory) !=
+  if (vkAllocateMemory(GetDevice(), &alloc_info, nullptr, memory) !=
       VK_SUCCESS) {
     FT_LOG(Error) << "Fail to allocate memory";
     return false;

--- a/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
+++ b/flutter/shell/platform/tizen/external_texture_pixel_vulkan.h
@@ -26,7 +26,7 @@ class ExternalTexturePixelVulkan : public ExternalVulkanTexture {
 
  private:
   bool AllocateMemory(const VkMemoryRequirements& memory_requirements,
-                      VkDeviceMemory& memory,
+                      VkDeviceMemory* memory,
                       VkMemoryPropertyFlags properties);
   bool CreateBuffer(VkDeviceSize required_size);
   bool CreateImage(size_t width, size_t height);

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan.cc
@@ -26,7 +26,7 @@ ExternalTextureSurfaceVulkan::~ExternalTextureSurfaceVulkan() {
 bool ExternalTextureSurfaceVulkan::CreateBuffer(
     const tbm_surface_h tbm_surface) {
   if (IsSupportDisjoint(tbm_surface)) {
-    /** TODO as I konw, skia doesn't support disjoint,we need consider to
+    /** TODO as I know, skia doesn't support disjoint,we need consider to
      *  implement buffer map solution.
     vulkan_buffer_ = std::make_unique<ExternalTextureSurfaceVulkanBufferMap>(
         vulkan_renderer_);

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
@@ -11,7 +11,8 @@ ExternalTextureSurfaceVulkanBuffer::ExternalTextureSurfaceVulkanBuffer(
     TizenRendererVulkan* vulkan_renderer)
     : vulkan_renderer_(vulkan_renderer) {}
 
-VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(tbm_format& format) {
+VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(
+    const tbm_format& format) {
   switch (format) {
     case TBM_FORMAT_NV12:
     case TBM_FORMAT_NV21:

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h"
 #include <vulkan/vulkan.h>
+#include "flutter/shell/platform/tizen/logger.h"
 
 namespace flutter {
 
@@ -28,6 +29,8 @@ VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(
     case TBM_FORMAT_BGRA8888:
       return VK_FORMAT_B8G8R8A8_UNORM;
     default:
+      FT_LOG(Warn) << "Unknown TBM format: " << format
+                   << ", returning VK_FORMAT_UNDEFINED";
       return VK_FORMAT_UNDEFINED;
   }
 }

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.cc
@@ -12,8 +12,7 @@ ExternalTextureSurfaceVulkanBuffer::ExternalTextureSurfaceVulkanBuffer(
     TizenRendererVulkan* vulkan_renderer)
     : vulkan_renderer_(vulkan_renderer) {}
 
-VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(
-    const tbm_format& format) {
+VkFormat ExternalTextureSurfaceVulkanBuffer::ConvertFormat(tbm_format format) {
   switch (format) {
     case TBM_FORMAT_NV12:
     case TBM_FORMAT_NV21:

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
@@ -30,7 +30,7 @@ class ExternalTextureSurfaceVulkanBuffer {
   virtual VkDeviceMemory GetMemory() = 0;
 
  protected:
-  VkFormat ConvertFormat(const tbm_format& format);
+  VkFormat ConvertFormat(tbm_format format);
   VkDevice GetDevice() const;
 
  private:

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer.h
@@ -30,7 +30,7 @@ class ExternalTextureSurfaceVulkanBuffer {
   virtual VkDeviceMemory GetMemory() = 0;
 
  protected:
-  VkFormat ConvertFormat(tbm_format& format);
+  VkFormat ConvertFormat(const tbm_format& format);
   VkDevice GetDevice() const;
 
  private:

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -71,7 +71,6 @@ bool ExternalTextureSurfaceVulkanBufferDma::CreateImage(
 }
 
 bool ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
-    VkDevice device,
     VkExternalMemoryHandleTypeFlagBits handleType,
     int fd,
     VkMemoryFdPropertiesKHR* pMemoryFdProperties) {
@@ -82,8 +81,8 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
     FT_LOG(Error) << "Fail to get vkGetMemoryFdPropertiesKHR";
     return false;
   }
-  VkResult result =
-      pfn_memory_fd_properties(device, handleType, fd, pMemoryFdProperties);
+  VkResult result = pfn_memory_fd_properties(GetDevice(), handleType, fd,
+                                             pMemoryFdProperties);
   return result == VK_SUCCESS;
 }
 
@@ -97,8 +96,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetFdMemoryTypeIndex(
   VkMemoryFdPropertiesKHR memory_fd_properties = {};
   memory_fd_properties.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
 
-  if (!GetMemoryFdPropertiesKHR(GetDevice(),
-                                VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+  if (!GetMemoryFdPropertiesKHR(VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
                                 fd, &memory_fd_properties)) {
     FT_LOG(Error) << "Fail to get memory fd properties";
     return false;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -82,7 +82,8 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
     FT_LOG(Error) << "Fail to get vkGetMemoryFdPropertiesKHR";
     return false;
   }
-  VkResult result = pfn_memory_fd_properties(device, handleType, fd, pMemoryFdProperties);
+  VkResult result =
+      pfn_memory_fd_properties(device, handleType, fd, pMemoryFdProperties);
   return result == VK_SUCCESS;
 }
 

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -70,7 +70,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::CreateImage(
   return true;
 }
 
-VkResult ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
+bool ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
     VkDevice device,
     VkExternalMemoryHandleTypeFlagBits handleType,
     int fd,
@@ -80,9 +80,10 @@ VkResult ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
           GetDevice(), "vkGetMemoryFdPropertiesKHR");
   if (!pfn_memory_fd_properties) {
     FT_LOG(Error) << "Fail to get vkGetMemoryFdPropertiesKHR";
-    return VK_ERROR_EXTENSION_NOT_PRESENT;
+    return false;
   }
-  return pfn_memory_fd_properties(device, handleType, fd, pMemoryFdProperties);
+  VkResult result = pfn_memory_fd_properties(device, handleType, fd, pMemoryFdProperties);
+  return result == VK_SUCCESS;
 }
 
 bool ExternalTextureSurfaceVulkanBufferDma::GetFdMemoryTypeIndex(
@@ -91,9 +92,9 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetFdMemoryTypeIndex(
   VkMemoryFdPropertiesKHR memory_fd_properties = {};
   memory_fd_properties.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
 
-  if (GetMemoryFdPropertiesKHR(GetDevice(),
-                               VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
-                               fd, &memory_fd_properties) != VK_SUCCESS) {
+  if (!GetMemoryFdPropertiesKHR(GetDevice(),
+                                VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+                                fd, &memory_fd_properties)) {
     FT_LOG(Error) << "Fail to get memory fd properties";
     return false;
   }

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.cc
@@ -88,7 +88,11 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetMemoryFdPropertiesKHR(
 
 bool ExternalTextureSurfaceVulkanBufferDma::GetFdMemoryTypeIndex(
     int fd,
-    uint32_t& index_out) {
+    uint32_t* index_out) {
+  if (index_out == nullptr) {
+    return false;
+  }
+
   VkMemoryFdPropertiesKHR memory_fd_properties = {};
   memory_fd_properties.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
 
@@ -101,7 +105,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::GetFdMemoryTypeIndex(
 
   for (uint32_t mem_idx = 0; mem_idx < VK_MAX_MEMORY_TYPES; mem_idx++) {
     if (memory_fd_properties.memoryTypeBits & (1 << mem_idx)) {
-      index_out = mem_idx;
+      *index_out = mem_idx;
       return true;
     }
   }
@@ -115,7 +119,7 @@ bool ExternalTextureSurfaceVulkanBufferDma::AllocateAndBindMemory(
   int bo_size = tbm_bo_size(bo);
 
   uint32_t memory_type_index = 0;
-  if (!GetFdMemoryTypeIndex(bo_fd, memory_type_index)) {
+  if (!GetFdMemoryTypeIndex(bo_fd, &memory_type_index)) {
     FT_LOG(Error) << "Fail to get memory type index";
     close(bo_fd);
     return false;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
@@ -24,13 +24,13 @@ class ExternalTextureSurfaceVulkanBufferDma
   VkImage GetImage() override;
   VkDeviceMemory GetMemory() override;
 
- private:
-  bool GetFdMemoryTypeIndex(int fd, uint32_t& index_out);
-  VkResult GetMemoryFdPropertiesKHR(
-      VkDevice device,
-      VkExternalMemoryHandleTypeFlagBits handleType,
-      int fd,
-      VkMemoryFdPropertiesKHR* pMemoryFdProperties);
+  private:
+   bool GetFdMemoryTypeIndex(int fd, uint32_t& index_out);
+   bool GetMemoryFdPropertiesKHR(
+       VkDevice device,
+       VkExternalMemoryHandleTypeFlagBits handleType,
+       int fd,
+       VkMemoryFdPropertiesKHR* pMemoryFdProperties);
   VkFormat texture_format_ = VK_FORMAT_UNDEFINED;
   VkImage texture_image_ = VK_NULL_HANDLE;
   VkDeviceMemory texture_device_memory_ = VK_NULL_HANDLE;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
@@ -25,7 +25,7 @@ class ExternalTextureSurfaceVulkanBufferDma
   VkDeviceMemory GetMemory() override;
 
   private:
-   bool GetFdMemoryTypeIndex(int fd, uint32_t& index_out);
+   bool GetFdMemoryTypeIndex(int fd, uint32_t* index_out);
    bool GetMemoryFdPropertiesKHR(
        VkDevice device,
        VkExternalMemoryHandleTypeFlagBits handleType,

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
@@ -24,13 +24,12 @@ class ExternalTextureSurfaceVulkanBufferDma
   VkImage GetImage() override;
   VkDeviceMemory GetMemory() override;
 
-  private:
-   bool GetFdMemoryTypeIndex(int fd, uint32_t* index_out);
-   bool GetMemoryFdPropertiesKHR(
-       VkDevice device,
-       VkExternalMemoryHandleTypeFlagBits handleType,
-       int fd,
-       VkMemoryFdPropertiesKHR* pMemoryFdProperties);
+ private:
+  bool GetFdMemoryTypeIndex(int fd, uint32_t* index_out);
+  bool GetMemoryFdPropertiesKHR(VkDevice device,
+                                VkExternalMemoryHandleTypeFlagBits handleType,
+                                int fd,
+                                VkMemoryFdPropertiesKHR* pMemoryFdProperties);
   VkFormat texture_format_ = VK_FORMAT_UNDEFINED;
   VkImage texture_image_ = VK_NULL_HANDLE;
   VkDeviceMemory texture_device_memory_ = VK_NULL_HANDLE;

--- a/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
+++ b/flutter/shell/platform/tizen/external_texture_surface_vulkan_buffer_dma.h
@@ -26,8 +26,7 @@ class ExternalTextureSurfaceVulkanBufferDma
 
  private:
   bool GetFdMemoryTypeIndex(int fd, uint32_t* index_out);
-  bool GetMemoryFdPropertiesKHR(VkDevice device,
-                                VkExternalMemoryHandleTypeFlagBits handleType,
+  bool GetMemoryFdPropertiesKHR(VkExternalMemoryHandleTypeFlagBits handleType,
                                 int fd,
                                 VkMemoryFdPropertiesKHR* pMemoryFdProperties);
   VkFormat texture_format_ = VK_FORMAT_UNDEFINED;


### PR DESCRIPTION
Main changes:
- Fix const correctness in ConvertFormat method
- Add warning log for unknown TBM format in ConvertFormat()
- Fix GetMemoryFdPropertiesKHR return type for consistency
- Fix GetFdMemoryTypeIndex output parameter to use pointer
- Fix: Change AllocateMemory output parameter from reference to pointer
- Fix vkMapMemory resource cleanup in ExternalTexturePixelVulkan
- Fix typo in comment: 'konw' -> 'know' in external_texture_surface_vulkan.cc
- Pass tbm_format by value instead of const reference
- Add null check to AllocateMemory function in ExternalTexturePixelVulkan
- Fix: Reset width_ and height_ on CopyBufferToImage failure