### PR TITLE
feat(texture): Tear down external textures on the render thread

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -330,7 +330,8 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
     int64_t texture_id,
     void (*callback)(void* user_data),
     void* user_data) {
-  TextureRegistrarFromHandle(texture_registrar)->UnregisterTexture(texture_id);
+  TextureRegistrarFromHandle(texture_registrar)->UnregisterTexture(
+      texture_id, callback, user_data);
 }
 
 bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(

--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -330,8 +330,8 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
     int64_t texture_id,
     void (*callback)(void* user_data),
     void* user_data) {
-  TextureRegistrarFromHandle(texture_registrar)->UnregisterTexture(
-      texture_id, callback, user_data);
+  TextureRegistrarFromHandle(texture_registrar)
+      ->UnregisterTexture(texture_id, callback, user_data);
 }
 
 bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -412,6 +412,24 @@ bool FlutterTizenEngine::MarkExternalTextureFrameAvailable(int64_t texture_id) {
               engine_, texture_id) == kSuccess);
 }
 
+void FlutterTizenEngine::PostRenderThreadTask(std::function<void()> task) {
+  if (!engine_) {
+    // The engine is shutting down (or never started); posting is unsafe.
+    // Run inline so the task's cleanup still happens rather than leaking.
+    task();
+    return;
+  }
+  auto* heap_task = new std::function<void()>(std::move(task));
+  embedder_api_.PostRenderThreadTask(
+      engine_,
+      [](void* data) {
+        auto* fn = static_cast<std::function<void()>*>(data);
+        (*fn)();
+        delete fn;
+      },
+      heap_task);
+}
+
 void FlutterTizenEngine::UpdateAccessibilityFeatures(bool invert_colors,
                                                      bool high_contrast) {
   int32_t flags = 0;

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.cc
@@ -420,14 +420,19 @@ void FlutterTizenEngine::PostRenderThreadTask(std::function<void()> task) {
     return;
   }
   auto* heap_task = new std::function<void()>(std::move(task));
-  embedder_api_.PostRenderThreadTask(
-      engine_,
-      [](void* data) {
-        auto* fn = static_cast<std::function<void()>*>(data);
-        (*fn)();
-        delete fn;
-      },
-      heap_task);
+  auto callback = [](void* data) {
+    auto* fn = static_cast<std::function<void()>*>(data);
+    (*fn)();
+    delete fn;
+  };
+  if (embedder_api_.PostRenderThreadTask(engine_, callback, heap_task) !=
+      kSuccess) {
+    // The engine began shutting down between the IsRunning() check above and
+    // this call, so the render thread task runner is no longer available.
+    // Run the task inline (as the trampoline would have) so its cleanup
+    // still happens rather than leaking heap_task.
+    callback(heap_task);
+  }
 }
 
 void FlutterTizenEngine::UpdateAccessibilityFeatures(bool invert_colors,

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -175,8 +175,9 @@ class FlutterTizenEngine {
   // Posts |task| onto the Flutter render (raster) thread. May be called from
   // any thread while the engine is running. Used to tear down external-texture
   // GPU resources on the thread that owns the GL context, after any in-flight
-  // frame callback for that texture has completed. Does nothing if the engine
-  // is not running.
+  // frame callback for that texture has completed. If the engine is not
+  // running, or posting fails because shutdown began concurrently, |task|
+  // runs inline instead.
   void PostRenderThreadTask(std::function<void()> task);
 
   // Dispatch accessibility action back to the Flutter framework.

--- a/flutter/shell/platform/tizen/flutter_tizen_engine.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_engine.h
@@ -6,6 +6,7 @@
 #ifndef EMBEDDER_FLUTTER_TIZEN_ENGINE_H_
 #define EMBEDDER_FLUTTER_TIZEN_ENGINE_H_
 
+#include <functional>
 #include <memory>
 
 #include "flutter/shell/platform/common/accessibility_bridge.h"
@@ -170,6 +171,13 @@ class FlutterTizenEngine {
   // Notifies the engine about a new frame being available for the
   // given |texture_id|.
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
+
+  // Posts |task| onto the Flutter render (raster) thread. May be called from
+  // any thread while the engine is running. Used to tear down external-texture
+  // GPU resources on the thread that owns the GL context, after any in-flight
+  // frame callback for that texture has completed. Does nothing if the engine
+  // is not running.
+  void PostRenderThreadTask(std::function<void()> task);
 
   // Dispatch accessibility action back to the Flutter framework.
   void DispatchAccessibilityAction(uint64_t target,

--- a/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -110,7 +110,15 @@ bool FlutterTizenTextureRegistrar::UnregisterTexture(int64_t texture_id,
         // glDeleteTextures in the texture's destructor targets the correct
         // context (the engine does not guarantee a current context when
         // running posted tasks).
-        if (gl_renderer) {
+        //
+        // If the engine has shut down between PostRenderThreadTask() being
+        // called and this task running, PostRenderThreadTask() runs the task
+        // inline and the renderer may already be destroyed, so skip
+        // OnMakeCurrent() to avoid touching a dangling GL context/renderer.
+        // UnregisterExternalTexture() stays unconditional: it is null-safe at
+        // the embedder boundary (a torn-down engine handle just yields an
+        // error) and is the registrar's core teardown step.
+        if (engine->IsRunning() && gl_renderer) {
           gl_renderer->OnMakeCurrent();
         }
         tex.reset();

--- a/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.cc
@@ -4,13 +4,14 @@
 
 #include "flutter_tizen_texture_registrar.h"
 
-#include <iostream>
+#include <memory>
 #include <mutex>
 
 #include "flutter/shell/platform/tizen/external_texture.h"
 #include "flutter/shell/platform/tizen/external_texture_surface_egl.h"
 #include "flutter/shell/platform/tizen/flutter_tizen_engine.h"
 #include "flutter/shell/platform/tizen/logger.h"
+#include "flutter/shell/platform/tizen/tizen_renderer_gl.h"
 
 namespace flutter {
 
@@ -67,16 +68,58 @@ int64_t FlutterTizenTextureRegistrar::RegisterTexture(
   return texture_id;
 }
 
-bool FlutterTizenTextureRegistrar::UnregisterTexture(int64_t texture_id) {
+bool FlutterTizenTextureRegistrar::UnregisterTexture(int64_t texture_id,
+                                                     void (*callback)(void*),
+                                                     void* user_data) {
+  std::unique_ptr<ExternalTexture> texture;
   {
     std::lock_guard<std::mutex> lock(map_mutex_);
     auto iter = textures_.find(texture_id);
     if (iter == textures_.end()) {
       return false;
     }
+    // Remove from the map first so no *new* PopulateGLTexture() lookup can
+    // find this texture. A PopulateGLTexture() already in flight on the render
+    // thread may still hold a raw pointer to it (it drops map_mutex_ before
+    // using the texture), so destruction is deferred to a render-thread task
+    // below.
+    texture = std::move(iter->second);
     textures_.erase(iter);
   }
-  return engine_->UnregisterExternalTexture(texture_id);
+
+  // Destroy the texture on the render thread rather than here on the calling
+  // (platform) thread. The engine runs this task only after any in-flight
+  // frame callback on the render thread has completed, so it cannot race with
+  // a PopulateGLTexture() that is still reading this texture. Tearing it down
+  // on the platform thread instead would let the backing TBM buffer be freed
+  // while the render thread still has it mapped/referenced -> heap corruption
+  // and the "tbm_bo_free ... lock_cnt" crash. Running on the render thread
+  // also puts glDeleteTextures on the thread that owns the GL context.
+  //
+  // The completion |callback| (used by webview_flutter_lwe to free its TBM
+  // buffer pool) is likewise invoked only after the render thread is done with
+  // the texture, giving the plugin a correct "safe to free" signal.
+  FlutterTizenEngine* engine = engine_;
+  auto* gl_renderer = dynamic_cast<TizenRendererGL*>(engine->renderer());
+  // shared_ptr (not unique_ptr): PostRenderThreadTask takes a copyable
+  // std::function, so the captured owner must be copyable.
+  std::shared_ptr<ExternalTexture> tex(std::move(texture));
+  engine->PostRenderThreadTask(
+      [engine, gl_renderer, texture_id, tex, callback, user_data]() mutable {
+        // On the render thread, make the render context current so
+        // glDeleteTextures in the texture's destructor targets the correct
+        // context (the engine does not guarantee a current context when
+        // running posted tasks).
+        if (gl_renderer) {
+          gl_renderer->OnMakeCurrent();
+        }
+        tex.reset();
+        engine->UnregisterExternalTexture(texture_id);
+        if (callback) {
+          callback(user_data);
+        }
+      });
+  return true;
 }
 
 bool FlutterTizenTextureRegistrar::MarkTextureFrameAvailable(

--- a/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.h
+++ b/flutter/shell/platform/tizen/flutter_tizen_texture_registrar.h
@@ -29,8 +29,14 @@ class FlutterTizenTextureRegistrar {
 
   // Attempts to unregister the texture identified by |texture_id|.
   //
-  // Returns true if the texture was successfully unregistered.
-  bool UnregisterTexture(int64_t texture_id);
+  // The texture's GPU resources are torn down asynchronously on the render
+  // thread (after any in-flight frame callback for it has completed); the
+  // optional |callback| (invoked with |user_data|) fires once that teardown
+  // is done. Returns true if the texture was found and scheduled for
+  // unregistration.
+  bool UnregisterTexture(int64_t texture_id,
+                         void (*callback)(void* user_data),
+                         void* user_data);
 
   // Notifies the engine about a new frame being available.
   //

--- a/flutter/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen_texture_registrar_unittests.cc
@@ -98,7 +98,7 @@ TEST_F(FlutterTizenTextureRegistrarTest, RegisterUnregisterTexture) {
   EXPECT_TRUE(registrar.MarkTextureFrameAvailable(texture_id));
   EXPECT_TRUE(mark_frame_available_called);
 
-  EXPECT_TRUE(registrar.UnregisterTexture(texture_id));
+  EXPECT_TRUE(registrar.UnregisterTexture(texture_id, nullptr, nullptr));
   EXPECT_TRUE(unregister_called);
 }
 


### PR DESCRIPTION
UnregisterTexture() previously destroyed the ExternalTexture (running glDeleteTextures) synchronously on the calling platform thread. That could race with an in-flight PopulateGLTexture() on the render thread and free the backing TBM buffer while the GPU still referenced it, causing heap corruption and "tbm_bo_free ... lock_cnt" crashes on the SW backend.

- Add a completion-callback parameter to UnregisterTexture, plumbed through FlutterDesktopTextureRegistrarUnregisterExternalTexture, so callers learn when teardown has actually completed.
- Add FlutterTizenEngine::PostRenderThreadTask(), a thin wrapper over the embedder API's PostRenderThreadTask.
- UnregisterTexture now removes the texture from the map (blocking new lookups), then posts its destruction to the render thread. The engine runs that task only after any in-flight frame callback has completed, so it no longer races; glDeleteTextures runs on the thread that owns the GL context, and the completion callback fires only once teardown is done.