### PR TITLE
Support vulkan pipeline cache

### DIFF
--- a/flutter/shell/platform/embedder/embedder.h
+++ b/flutter/shell/platform/embedder/embedder.h
@@ -1059,6 +1059,11 @@ typedef struct {
   /// that external texture details can be supplied to the engine for subsequent
   /// composition.
   FlutterVulkanTextureFrameCallback external_texture_frame_callback;
+  /// The path to the Vulkan pipeline cache data.
+  /// The string can be collected after the call to `FlutterEngineRun` returns.
+  /// The string must be NULL terminated.
+  /// If NULL, Impeller will not use the Vulkan pipeline cache.
+  const char* cache_path;
 } FlutterVulkanRendererConfig;
 
 typedef struct {

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/tizen/tizen_renderer_vulkan.h"
 
+#include <app.h>
 #include <stddef.h>
 #include <optional>
 #include "flutter/shell/platform/tizen/external_texture_pixel_vulkan.h"
@@ -49,6 +50,11 @@ TizenRendererVulkan::TizenRendererVulkan(TizenViewBase* view) {
   FT_LOG(Info) << "Vulkan version: " << VK_VERSION_MAJOR(version) << "."
                << VK_VERSION_MINOR(version) << "." << VK_VERSION_PATCH(version);
 
+  char* cache_path = app_get_cache_path();
+  if (cache_path) {
+    cache_path_ = cache_path;
+    free(cache_path);
+  }
   InitVulkan(view);
 }
 
@@ -200,6 +206,7 @@ FlutterRendererConfig TizenRendererVulkan::GetRendererConfig() {
     return engine->texture_registrar()->PopulateVulkanTexture(texture_id, width,
                                                               height, texture);
   };
+  config.vulkan.cache_path = cache_path_.c_str();
   return config;
 }
 

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -206,7 +206,8 @@ FlutterRendererConfig TizenRendererVulkan::GetRendererConfig() {
     return engine->texture_registrar()->PopulateVulkanTexture(texture_id, width,
                                                               height, texture);
   };
-  config.vulkan.cache_path = cache_path_.c_str();
+  config.vulkan.cache_path =
+      cache_path_.empty() ? nullptr : cache_path_.c_str();
   return config;
 }
 

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.cc
@@ -54,6 +54,9 @@ TizenRendererVulkan::TizenRendererVulkan(TizenViewBase* view) {
   if (cache_path) {
     cache_path_ = cache_path;
     free(cache_path);
+  } else {
+    FT_LOG(Warn)
+        << "app_get_cache_path() failed. Vulkan pipeline cache is disabled.";
   }
   InitVulkan(view);
 }

--- a/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
+++ b/flutter/shell/platform/tizen/tizen_renderer_vulkan.h
@@ -105,6 +105,7 @@ class TizenRendererVulkan : public TizenRenderer {
   bool resize_pending_ = false;
   int32_t width_ = 0;
   int32_t height_ = 0;
+  std::string cache_path_;
 };
 }  // namespace flutter
 


### PR DESCRIPTION
Fix https://github.com/flutter-tizen/embedder/issues/181

The cache is now successfully generated and loaded when the app starts.

Currently, no significant speedup effect from VkPipelineCache is observed on RPI4, largely due to the small number of pipelines, simple structure, or small initialization scale.

Due to issues with the Vulkan driver on TVs, this PR cannot be verified on TVs.