### PR TITLE
Restore FlutterDesktopViewGetNativeHandle API

### DIFF
--- a/flutter/shell/platform/tizen/flutter_tizen.cc
+++ b/flutter/shell/platform/tizen/flutter_tizen.cc
@@ -219,6 +219,11 @@ FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
   return HandleForView(view.release());
 }
 
+void* FlutterDesktopViewGetNativeHandle(FlutterDesktopViewRef view_ref) {
+  flutter::FlutterTizenView* view = ViewFromHandle(view_ref);
+  return view->tizen_view()->GetNativeHandle();
+}
+
 uint32_t FlutterDesktopViewGetResourceId(FlutterDesktopViewRef view_ref) {
   flutter::FlutterTizenView* view = ViewFromHandle(view_ref);
   return view->tizen_view()->GetResourceId();

--- a/flutter/shell/platform/tizen/public/flutter_tizen.h
+++ b/flutter/shell/platform/tizen/public/flutter_tizen.h
@@ -177,6 +177,13 @@ FLUTTER_EXPORT FlutterDesktopViewRef FlutterDesktopViewCreateFromNewWindow(
 // @warning This API is a work-in-progress and may change.
 FLUTTER_EXPORT void FlutterDesktopViewDestroy(FlutterDesktopViewRef view);
 
+// Returns a native UI toolkit handle for manipulation in host application.
+//
+// Cast the returned void* to Ecore_Wl2_Window*.
+// @warning This API is a work-in-progress and may change.
+FLUTTER_EXPORT void* FlutterDesktopViewGetNativeHandle(
+    FlutterDesktopViewRef view);
+
 // Returns the resource id of current window.
 FLUTTER_EXPORT uint32_t
 FlutterDesktopViewGetResourceId(FlutterDesktopViewRef view);


### PR DESCRIPTION
The API was removed along with the NUI/Dali embedding support in #184, but it is not NUI-specific: it returns the Ecore_Wl2_Window* backing a window-based view and is used by several plugins (tizen_window_manager, webview_flutter, flutter_inappwebview, video_player_avplay, video_player_videohole). Restore only this API so those plugins build again, keeping the rest of the NUI removal intact.

Fixes flutter-tizen/flutter-tizen#796