### PR TITLE
Support gcc 10+ toolchains in accessibility headers

### DIFF
--- a/flutter/third_party/accessibility/ax/ax_active_popup.h
+++ b/flutter/third_party/accessibility/ax/ax_active_popup.h
@@ -5,6 +5,7 @@
 #ifndef UI_ACCESSIBILITY_AX_ACTIVE_POPUP_H_
 #define UI_ACCESSIBILITY_AX_ACTIVE_POPUP_H_
 
+#include <cstdint>
 #include <optional>
 
 #include "ax/ax_export.h"

--- a/flutter/third_party/accessibility/ax/ax_event_generator.h
+++ b/flutter/third_party/accessibility/ax/ax_event_generator.h
@@ -125,9 +125,13 @@ class AX_EXPORT AXEventGenerator : public AXTreeObserver {
     const EventParams& event_params;
   };
 
-  class AX_EXPORT Iterator
-      : public std::iterator<std::input_iterator_tag, TargetedEvent> {
+  class AX_EXPORT Iterator {
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = TargetedEvent;
+    using difference_type = std::ptrdiff_t;
+    using pointer = TargetedEvent*;
+    using reference = TargetedEvent&;
     Iterator(
         const std::map<AXNode*, std::set<EventParams>>& map,
         const std::map<AXNode*, std::set<EventParams>>::const_iterator& head);

--- a/flutter/third_party/accessibility/ax/ax_range.h
+++ b/flutter/third_party/accessibility/ax/ax_range.h
@@ -190,8 +190,14 @@ class AXRange {
   //
   // This class allows AXRange to be iterated through all "leaf text ranges"
   // contained between its endpoints, composing the entire range.
-  class Iterator : public std::iterator<std::input_iterator_tag, AXRange> {
+  class Iterator {
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = AXRange;
+    using difference_type = std::ptrdiff_t;
+    using pointer = AXRange*;
+    using reference = AXRange&;
+
     Iterator()
         : current_start_(AXPositionType::CreateNullPosition()),
           iterator_end_(AXPositionType::CreateNullPosition()) {}


### PR DESCRIPTION
gcc 9.2.0 (Tizen 6.0/6.5/8.0) compiles these headers as-is, gcc 10 and later do not. Verified clean at -std=c++17 -Werror against gcc 9.2.0 (arm, arm64, x64 sysroots), libstdc++ 10, 11, 12, 13 and gcc 14.2.0 (Tizen 11.0 arm64).

AXEventGenerator::Iterator now matches the current Chromium implementation, which spells out the five iterator_traits typedefs instead of deriving from the deprecated std::iterator: https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/ax_event_generator.h