### PR TITLE
[ci] run release job on main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
 
   release:
     needs: test
-    if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'main') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Keep master in the condition until the default branch is renamed so that pushes before the rename still create releases.

https://github.com/flutter-tizen/flutter-tizen/issues/805